### PR TITLE
[OLD] d3 version upgrade (4.4.0)

### DIFF
--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1037,7 +1037,7 @@ const TreeMapExample = (props) => {
     }))
   };
 
-  const colorScale = d3.scale.linear()
+  const colorScale = d3.scaleLinear()
     .domain([0, 65])
     .range(['#6b6ecf', '#8ca252'])
     .interpolate(d3.interpolateHcl);

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -107,7 +107,6 @@ const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", 
 
 
 const LineChartExample = (props) => {
-  // const colors = d3.scale.category10().domain(_.range(10));
   const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
   return <div>
@@ -147,7 +146,7 @@ class LineChartExample2 extends React.Component {
 
   render() {
     const {activeX} = this.state;
-    const colors = d3.scale.category10().domain(_.range(10));
+    const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
     const line1 = d => Math.sin(d*.1);
     const line2 = d => Math.cos(d*.1);

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -107,7 +107,8 @@ const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", 
 
 
 const LineChartExample = (props) => {
-  const colors = d3.scale.category10().domain(_.range(10));
+  // const colors = d3.scale.category10().domain(_.range(10));
+  const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
   return <div>
     <XYPlot scaleType="linear" {...{width: 600, height: 350, domain: {x: [-20, 150]}}}>

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';
@@ -98,9 +98,9 @@ const barTickData = {
 };
 //console.log('rangeValue', rangeValueData);
 
-const normalDistribution = d3.random.normal(0);
+const normalDistribution = d3.randomNormal(0);
 //const randomNormal = _.times(1000, normalDistribution);
-const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.random.normal(3, 0.5)));
+const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.randomNormal(3, 0.5)));
 
 const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", "😉", "😊", "😐", "😑", "😒", "😓", "😔", "😕", "😖", "😗", "😘", "😙", "😚", "😛", "😜", "😝", "👻", "👹", "👺", "💩", "💀", "👽", "👾", "🙇", "💁", "🙅", "🙆", "🙋", "🙎", "🙍", "💆", "💇"];
 // end fake data

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "enzyme": "env NODE_PATH=$NODE_PATH:$PWD/src BABEL_ENV=production mocha --compilers js:babel-register --require test-enzyme/setup.js --recursive test-enzyme/spec"
   },
   "dependencies": {
-    "d3": "^3.5.6",
+    "d3": "^4.4.0",
     "invariant": "^2.2.0",
     "jquery": "^2.1.4",
     "lodash": "^4.5.1",

--- a/src/AreaChart.js
+++ b/src/AreaChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {makeAccessor, domainFromData, combineDomains} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/AreaChart.js
+++ b/src/AreaChart.js
@@ -45,7 +45,7 @@ export default class AreaChart extends React.Component {
     const {name, data, getX, getY, getYEnd, scale, pathStyle} = this.props;
     const accessors = {x: makeAccessor(getX), y: makeAccessor(getY), yEnd: makeAccessor(getYEnd)};
 
-    const areaGenerator = d3.svg.area();
+    const areaGenerator = d3.area();
     areaGenerator
       .x((d, i) => scale.x(accessors.x(d, i)))
       .y0((d, i) => scale.y(accessors.y(d, i)))

--- a/src/AreaHeatmap.js
+++ b/src/AreaHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -25,7 +25,7 @@ function makeColorScale(domain, colors, interpolator) {
   if(_.isString(interpolator))
     interpolator = interpolatorFromType(interpolator);
 
-  return d3.scale.linear()
+  return d3.scaleLinear()
     .domain(domain)
     .range(colors)
     .interpolate(interpolator);

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -35,7 +35,7 @@ export default class ColorHeatmap extends React.Component {
   static propTypes = {
     // passed from xyplot
     scale: CustomPropTypes.xyObjectOf(React.PropTypes.func.isRequired),
-    
+
     // data array - should be 1D array of all grid values
     // (if you have a 2D array, _.flatten it)
     data: React.PropTypes.array.isRequired,

--- a/src/FunnelChart.js
+++ b/src/FunnelChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import AreaBarChart from './AreaBarChart';
 

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
 import LineChart from './LineChart.js';

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import shallowEqual from './utils/shallowEqual';
 
 import {makeAccessor} from './utils/Data';

--- a/src/MarkerLineChart.js
+++ b/src/MarkerLineChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/PieChart.js
+++ b/src/PieChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {makeAccessor} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import resolveObjectProps from './utils/resolveObjectProps';
 import resolveXYScales from './utils/resolveXYScales';

--- a/src/old/BarChart.js
+++ b/src/old/BarChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {accessor, AccessorPropType, InterfaceMixin, methodIfFuncProp} from './util.js';
 

--- a/src/old/XYPlot.js
+++ b/src/old/XYPlot.js
@@ -1,7 +1,7 @@
 import React from 'react';
 //const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import {accessor} from '../util.js';
 import moment from 'moment';
 import numeral from 'numeral';

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import React from 'react';
 
 /**

--- a/src/utils/Margin.js
+++ b/src/utils/Margin.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 export const zeroMargin = {top: 0, bottom: 0, left: 0, right: 0};
 

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {combineDomains, domainFromData} from './Data';
 

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -42,11 +42,11 @@ export function inferScaleType(scale) {
 
 export function initScale(scaleType) {
   switch(scaleType) {
-    case 'linear': return d3.scale.linear();
-    case 'time': return d3.time.scale();
-    case 'ordinal': return d3.scale.ordinal();
-    case 'log': return d3.scale.log();
-    case 'pow': return d3.scale.pow();
+    case 'linear': return d3.scaleLinear();
+    case 'time': return d3.scaleTime();
+    case 'ordinal': return d3.scaleOrdinal();
+    case 'log': return d3.scaleLog();
+    case 'pow': return d3.scalePow();
   }
 }
 

--- a/src/utils/resolveXYScales.js
+++ b/src/utils/resolveXYScales.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import * as d3 from 'd3';
 import React from 'react';
 import invariant from 'invariant';
 
@@ -356,12 +357,15 @@ export default function resolveXYScales(ComposedComponent) {
         if(hasScaleFor(scale, k)) return [k, scale[k]];
 
         // create scale from domain/range
+        // PM/ER December 19, 2016 - Unsure whether or not this is the best approach.
+        //                           Importing d3 in this file also seems wrong. Graphs render correctly.
+        let kScale;
         const rangeMethod = (scaleType[k] === 'ordinal') ? 'rangePoints' : 'range';
-        const kScale = initScale(scaleType[k])
-          .domain(domain[k])[rangeMethod](range[k]);
-
-
-
+        if (scaleType[k] === 'ordinal') {
+          kScale = d3.scalePoint().domain(domain[k]).range(range[k]);
+        } else {
+          kScale = initScale(scaleType[k]).domain(domain[k])[rangeMethod](range[k]);
+        }
 
         // todo - ticks, nice and getDomain should be an axis prop instead, and axis should have getDomain
 


### PR DESCRIPTION
Upgrades d3 to version 4.4.0 and performs the necessary syntax changes.

Todo:
- [ ] Histogram - @erosenberg working on
- [ ] Treemap
- [x] Funnel Chart
- [ ] Custom Chart Children (mouse events not working correctly) @pmilla1606 working on
- [ ] Import only what's required per chart type (e.g.: `import {scaleLinear} from 'd3-scale'` instead of `import * as d3 from 'd3'`