### PR TITLE
d3 version upgrade (4.4.0)

### DIFF
--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';
@@ -98,16 +98,16 @@ const barTickData = {
 };
 //console.log('rangeValue', rangeValueData);
 
-const normalDistribution = d3.random.normal(0);
+const normalDistribution = d3.randomNormal(0);
 //const randomNormal = _.times(1000, normalDistribution);
-const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.random.normal(3, 0.5)));
+const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.randomNormal(3, 0.5)));
 
 const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", "😉", "😊", "😐", "😑", "😒", "😓", "😔", "😕", "😖", "😗", "😘", "😙", "😚", "😛", "😜", "😝", "👻", "👹", "👺", "💩", "💀", "👽", "👾", "🙇", "💁", "🙅", "🙆", "🙋", "🙎", "🙍", "💆", "💇"];
 // end fake data
 
 
 const LineChartExample = (props) => {
-  const colors = d3.scale.category10().domain(_.range(10));
+  const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
   return <div>
     <XYPlot scaleType="linear" {...{width: 600, height: 350, domain: {x: [-20, 150]}}}>
@@ -146,7 +146,7 @@ class LineChartExample2 extends React.Component {
 
   render() {
     const {activeX} = this.state;
-    const colors = d3.scale.category10().domain(_.range(10));
+    const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
     const line1 = d => Math.sin(d*.1);
     const line2 = d => Math.cos(d*.1);
@@ -1037,7 +1037,7 @@ const TreeMapExample = (props) => {
     }))
   };
 
-  const colorScale = d3.scale.linear()
+  const colorScale = d3.scaleLinear()
     .domain([0, 65])
     .range(['#6b6ecf', '#8ca252'])
     .interpolate(d3.interpolateHcl);

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {randomNormal, scaleOrdinal, scaleLinear, schemeCategory10, interpolateHcl} from 'd3';
+import * as d3 from 'd3';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';
@@ -84,6 +84,7 @@ const randomBarData2 = {
 
 const variableBins = _.range(0,12).reduce((bins, i) => {
   const lastBinEnd = bins.length ? _.last(bins)[1] : 0;
+  //return bins.concat([[lastBinEnd, lastBinEnd + _.random(5, 20)]])
   return bins.concat([[lastBinEnd, lastBinEnd + i]])
 }, []);
 
@@ -95,17 +96,18 @@ const barTickData = {
   numberNumber: randomBarData2.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
   numberRangeNumber: rangeValueData.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
 };
+//console.log('rangeValue', rangeValueData);
 
-
-const normalDistribution = randomNormal(0);
-const randomNormalArr = _.times(1000, normalDistribution).concat(_.times(1000, randomNormal(3, 0.5)));
+const normalDistribution = d3.randomNormal(0);
+//const randomNormal = _.times(1000, normalDistribution);
+const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.randomNormal(3, 0.5)));
 
 const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", "😉", "😊", "😐", "😑", "😒", "😓", "😔", "😕", "😖", "😗", "😘", "😙", "😚", "😛", "😜", "😝", "👻", "👹", "👺", "💩", "💀", "👽", "👾", "🙇", "💁", "🙅", "🙆", "🙋", "🙎", "🙍", "💆", "💇"];
 // end fake data
 
 
 const LineChartExample = (props) => {
-  const colors = scaleOrdinal(schemeCategory10);
+  const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
   return <div>
     <XYPlot scaleType="linear" {...{width: 600, height: 350, domain: {x: [-20, 150]}}}>
@@ -144,7 +146,7 @@ class LineChartExample2 extends React.Component {
 
   render() {
     const {activeX} = this.state;
-    const colors = scaleOrdinal(schemeCategory10);
+    const colors = d3.scaleOrdinal(d3.schemeCategory10);
 
     const line1 = d => Math.sin(d*.1);
     const line2 = d => Math.cos(d*.1);
@@ -738,16 +740,16 @@ const HistogramKDEExample = (props) => {
       <XYPlot margin={{left: 40, right: 8}} width={700} height={300}>
         <XAxis /><YAxis />
         <Histogram
-          data={randomNormalArr} getX={null}
+          data={randomNormal} getValue={null}
         />
         <KernelDensityEstimation
-          data={randomNormalArr} getX={null} bandwidth={0.5}
+          data={randomNormal} getX={null} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormalArr} getX={null} bandwidth={0.1}
+          data={randomNormal} getX={null} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormalArr} getX={null} bandwidth={2}
+          data={randomNormal} getX={null} bandwidth={2}
         />
       </XYPlot>
     </div>
@@ -760,7 +762,7 @@ const HistogramKDEExample = (props) => {
         showTicks={false}
       >
         <ScatterPlot
-          data={randomNormalArr}
+          data={randomNormal}
           getX={null}
           getY={() => Math.random()}
           pointRadius={1}
@@ -1007,16 +1009,16 @@ const KDEExample = (props) => {
         <YAxis title="Count" />
 
         <KernelDensityEstimation
-          data={randomNormalArr} getValue={{x: null}} bandwidth={0.5}
+          data={randomNormal} getValue={{x: null}} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormalArr} getValue={{x: null}} bandwidth={0.1}
+          data={randomNormal} getValue={{x: null}} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormalArr} getValue={{x: null}} bandwidth={2}
+          data={randomNormal} getValue={{x: null}} bandwidth={2}
         />
         <ScatterPlot
-          data={randomNormalArr}
+          data={randomNormal}
           getX={null}
           getY={d => Math.abs(d) * 10000 % 200}
           pointRadius={1}
@@ -1035,10 +1037,10 @@ const TreeMapExample = (props) => {
     }))
   };
 
-  const colorScale = scaleLinear()
+  const colorScale = d3.scaleLinear()
     .domain([0, 65])
     .range(['#6b6ecf', '#8ca252'])
-    .interpolate(interpolateHcl);
+    .interpolate(d3.interpolateHcl);
 
   return <div>
     <TreeMap

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -105,7 +105,7 @@ const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", 
 
 
 const LineChartExample = (props) => {
-  const colors = d3.scaleOrdinal(d3.schemeCategory10);
+  const colors = scaleOrdinal(schemeCategory10);
 
   return <div>
     <XYPlot scaleType="linear" {...{width: 600, height: 350, domain: {x: [-20, 150]}}}>
@@ -144,7 +144,7 @@ class LineChartExample2 extends React.Component {
 
   render() {
     const {activeX} = this.state;
-    const colors = d3.scaleOrdinal(d3.schemeCategory10);
+    const colors = scaleOrdinal(schemeCategory10);
 
     const line1 = d => Math.sin(d*.1);
     const line2 = d => Math.cos(d*.1);
@@ -1035,10 +1035,10 @@ const TreeMapExample = (props) => {
     }))
   };
 
-  const colorScale = d3.scaleLinear()
+  const colorScale = scaleLinear()
     .domain([0, 65])
     .range(['#6b6ecf', '#8ca252'])
-    .interpolate(d3.interpolateHcl);
+    .interpolate(interpolateHcl);
 
   return <div>
     <TreeMap

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,5 +1,7 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {randomNormal} from 'd3-random';
+import {scaleOrdinal, scaleLinear, schemeCategory10} from 'd3-scale';
+import {interpolateHcl} from 'd3-interpolate';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';
@@ -84,7 +86,6 @@ const randomBarData2 = {
 
 const variableBins = _.range(0,12).reduce((bins, i) => {
   const lastBinEnd = bins.length ? _.last(bins)[1] : 0;
-  //return bins.concat([[lastBinEnd, lastBinEnd + _.random(5, 20)]])
   return bins.concat([[lastBinEnd, lastBinEnd + i]])
 }, []);
 
@@ -96,18 +97,17 @@ const barTickData = {
   numberNumber: randomBarData2.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
   numberRangeNumber: rangeValueData.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
 };
-//console.log('rangeValue', rangeValueData);
 
-const normalDistribution = d3.randomNormal(0);
-//const randomNormal = _.times(1000, normalDistribution);
-const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.randomNormal(3, 0.5)));
+
+const normalDistribution = randomNormal(0);
+const randomNormalArr = _.times(1000, normalDistribution).concat(_.times(1000, randomNormal(3, 0.5)));
 
 const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", "😉", "😊", "😐", "😑", "😒", "😓", "😔", "😕", "😖", "😗", "😘", "😙", "😚", "😛", "😜", "😝", "👻", "👹", "👺", "💩", "💀", "👽", "👾", "🙇", "💁", "🙅", "🙆", "🙋", "🙎", "🙍", "💆", "💇"];
 // end fake data
 
 
 const LineChartExample = (props) => {
-  const colors = d3.scaleOrdinal(d3.schemeCategory10);
+  const colors = scaleOrdinal(schemeCategory10);
 
   return <div>
     <XYPlot scaleType="linear" {...{width: 600, height: 350, domain: {x: [-20, 150]}}}>
@@ -146,7 +146,7 @@ class LineChartExample2 extends React.Component {
 
   render() {
     const {activeX} = this.state;
-    const colors = d3.scaleOrdinal(d3.schemeCategory10);
+    const colors = scaleOrdinal(schemeCategory10);
 
     const line1 = d => Math.sin(d*.1);
     const line2 = d => Math.cos(d*.1);
@@ -740,16 +740,16 @@ const HistogramKDEExample = (props) => {
       <XYPlot margin={{left: 40, right: 8}} width={700} height={300}>
         <XAxis /><YAxis />
         <Histogram
-          data={randomNormal} getX={null}
+          data={randomNormalArr} getX={null}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={0.5}
+          data={randomNormalArr} getX={null} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={0.1}
+          data={randomNormalArr} getX={null} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={2}
+          data={randomNormalArr} getX={null} bandwidth={2}
         />
       </XYPlot>
     </div>
@@ -762,7 +762,7 @@ const HistogramKDEExample = (props) => {
         showTicks={false}
       >
         <ScatterPlot
-          data={randomNormal}
+          data={randomNormalArr}
           getX={null}
           getY={() => Math.random()}
           pointRadius={1}
@@ -1009,16 +1009,16 @@ const KDEExample = (props) => {
         <YAxis title="Count" />
 
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={0.5}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={0.1}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={2}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={2}
         />
         <ScatterPlot
-          data={randomNormal}
+          data={randomNormalArr}
           getX={null}
           getY={d => Math.abs(d) * 10000 % 200}
           pointRadius={1}
@@ -1037,10 +1037,10 @@ const TreeMapExample = (props) => {
     }))
   };
 
-  const colorScale = d3.scaleLinear()
+  const colorScale = scaleLinear()
     .domain([0, 65])
     .range(['#6b6ecf', '#8ca252'])
-    .interpolate(d3.interpolateHcl);
+    .interpolate(interpolateHcl);
 
   return <div>
     <TreeMap

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {randomNormal, scaleOrdinal, scaleLinear, schemeCategory10, interpolateHcl} from 'd3';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';
@@ -96,11 +96,9 @@ const barTickData = {
   numberNumber: randomBarData2.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
   numberRangeNumber: rangeValueData.numberNumber.map(d => [d[0], d[1] + _.random(-5000, 5000)]),
 };
-//console.log('rangeValue', rangeValueData);
 
-const normalDistribution = d3.randomNormal(0);
-//const randomNormal = _.times(1000, normalDistribution);
-const randomNormal = _.times(1000, normalDistribution).concat(_.times(1000, d3.randomNormal(3, 0.5)));
+const normalDistribution = randomNormal(0);
+const randomNormalArr = _.times(1000, normalDistribution).concat(_.times(1000, randomNormal(3, 0.5)));
 
 const emojis = ["😀", "😁", "😂", "😅", "😆", "😇", "😈", "👿", "😉", "😊", "😐", "😑", "😒", "😓", "😔", "😕", "😖", "😗", "😘", "😙", "😚", "😛", "😜", "😝", "👻", "👹", "👺", "💩", "💀", "👽", "👾", "🙇", "💁", "🙅", "🙆", "🙋", "🙎", "🙍", "💆", "💇"];
 // end fake data
@@ -740,16 +738,16 @@ const HistogramKDEExample = (props) => {
       <XYPlot margin={{left: 40, right: 8}} width={700} height={300}>
         <XAxis /><YAxis />
         <Histogram
-          data={randomNormal} getValue={null}
+          data={randomNormalArr} getValue={null}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={0.5}
+          data={randomNormalArr} getX={null} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={0.1}
+          data={randomNormalArr} getX={null} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormal} getX={null} bandwidth={2}
+          data={randomNormalArr} getX={null} bandwidth={2}
         />
       </XYPlot>
     </div>
@@ -762,7 +760,7 @@ const HistogramKDEExample = (props) => {
         showTicks={false}
       >
         <ScatterPlot
-          data={randomNormal}
+          data={randomNormalArr}
           getX={null}
           getY={() => Math.random()}
           pointRadius={1}
@@ -1009,16 +1007,16 @@ const KDEExample = (props) => {
         <YAxis title="Count" />
 
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={0.5}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={0.5}
         />
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={0.1}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={0.1}
         />
         <KernelDensityEstimation
-          data={randomNormal} getValue={{x: null}} bandwidth={2}
+          data={randomNormalArr} getValue={{x: null}} bandwidth={2}
         />
         <ScatterPlot
-          data={randomNormal}
+          data={randomNormalArr}
           getX={null}
           getY={d => Math.abs(d) * 10000 % 200}
           pointRadius={1}

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1,7 +1,5 @@
 import _ from 'lodash';
-import {randomNormal} from 'd3-random';
-import {scaleOrdinal, scaleLinear, schemeCategory10} from 'd3-scale';
-import {interpolateHcl} from 'd3-interpolate';
+import {randomNormal, scaleOrdinal, scaleLinear, schemeCategory10, interpolateHcl} from 'd3';
 import React from 'react';
 import update from 'react-addons-update';
 import numeral from 'numeral';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "enzyme": "env NODE_PATH=$NODE_PATH:$PWD/src BABEL_ENV=production mocha --compilers js:babel-register --require test-enzyme/setup.js --recursive test-enzyme/spec"
   },
   "dependencies": {
-    "d3": "^3.5.6",
+    "d3": "^4.4.0",
     "invariant": "^2.2.0",
     "jquery": "^2.1.4",
     "lodash": "^4.5.1",
@@ -47,6 +47,7 @@
     "less-loader": "^2.2.0",
     "mocha": "^2.3.3",
     "mocha-phantomjs": "^4.0.1",
+    "react": "^0.14.2",
     "react-addons-test-utils": "^0.14.2",
     "react-addons-update": "^0.14.2",
     "react-dom": "^0.14.2",

--- a/src/AreaChart.js
+++ b/src/AreaChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {area} from 'd3';
 
 import {makeAccessor, domainFromData, combineDomains} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -45,7 +45,7 @@ export default class AreaChart extends React.Component {
     const {name, data, getX, getY, getYEnd, scale, pathStyle} = this.props;
     const accessors = {x: makeAccessor(getX), y: makeAccessor(getY), yEnd: makeAccessor(getYEnd)};
 
-    const areaGenerator = d3.area();
+    const areaGenerator = area();
     areaGenerator
       .x((d, i) => scale.x(accessors.x(d, i)))
       .y0((d, i) => scale.y(accessors.y(d, i)))

--- a/src/AreaChart.js
+++ b/src/AreaChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {makeAccessor, domainFromData, combineDomains} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -45,7 +45,7 @@ export default class AreaChart extends React.Component {
     const {name, data, getX, getY, getYEnd, scale, pathStyle} = this.props;
     const accessors = {x: makeAccessor(getX), y: makeAccessor(getY), yEnd: makeAccessor(getYEnd)};
 
-    const areaGenerator = d3.svg.area();
+    const areaGenerator = d3.area();
     areaGenerator
       .x((d, i) => scale.x(accessors.x(d, i)))
       .y0((d, i) => scale.y(accessors.y(d, i)))

--- a/src/AreaHeatmap.js
+++ b/src/AreaHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {extent} from 'd3-array';
+import {extent} from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/AreaHeatmap.js
+++ b/src/AreaHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/AreaHeatmap.js
+++ b/src/AreaHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {extent} from 'd3-array';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';
@@ -19,8 +19,8 @@ export default class AreaHeatmap extends React.Component {
   static getDomain(props) {
     const {data, getX, getXEnd, getY, getYEnd} = props;
     return {
-      x: d3.extent(_.flatten([data.map(makeAccessor(getX)), data.map(makeAccessor(getXEnd))])),
-      y: d3.extent(_.flatten([data.map(makeAccessor(getY)), data.map(makeAccessor(getYEnd))]))
+      x: extent(_.flatten([data.map(makeAccessor(getX)), data.map(makeAccessor(getXEnd))])),
+      y: extent(_.flatten([data.map(makeAccessor(getY)), data.map(makeAccessor(getYEnd))]))
     };
   }
 

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {interpolateHcl, interpolateHsl, interpolateLab, interpolateRgb} from 'd3-interpolate';
-import {scaleLinear} from 'd3-scale';
+import {scaleLinear, interpolateHcl, interpolateHsl, interpolateLab, interpolateRgb} from 'd3';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -25,7 +25,7 @@ function makeColorScale(domain, colors, interpolator) {
   if(_.isString(interpolator))
     interpolator = interpolatorFromType(interpolator);
 
-  return d3.scale.linear()
+  return d3.scaleLinear()
     .domain(domain)
     .range(colors)
     .interpolate(interpolator);
@@ -35,7 +35,7 @@ export default class ColorHeatmap extends React.Component {
   static propTypes = {
     // passed from xyplot
     scale: CustomPropTypes.xyObjectOf(React.PropTypes.func.isRequired),
-    
+
     // data array - should be 1D array of all grid values
     // (if you have a 2D array, _.flatten it)
     data: React.PropTypes.array.isRequired,

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {interpolateHcl, interpolateHsl, interpolateLab, interpolateRgb} from 'd3-interpolate';
+import {scaleLinear} from 'd3-scale';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -11,11 +12,11 @@ import RangeRect from './RangeRect';
 
 function interpolatorFromType(type) {
   switch(type.toLowerCase()) {
-    case 'hcl': return d3.interpolateHcl;
-    case 'hsl': return d3.interpolateHsl;
-    case 'lab': return d3.interpolateLab;
-    case 'rgb': return d3.interpolateRgb;
-    default: return d3.interpolateHsl;
+    case 'hcl': return interpolateHcl;
+    case 'hsl': return interpolateHsl;
+    case 'lab': return interpolateLab;
+    case 'rgb': return interpolateRgb;
+    default: return interpolateHsl;
   }
 }
 
@@ -25,7 +26,13 @@ function makeColorScale(domain, colors, interpolator) {
   if(_.isString(interpolator))
     interpolator = interpolatorFromType(interpolator);
 
-  return d3.scaleLinear()
+  // const interp = scaleLinear()
+  //   .domain(domain)
+  //   .range(colors);
+
+  debugger;
+
+  return scaleLinear()
     .domain(domain)
     .range(colors)
     .interpolate(interpolator);
@@ -77,7 +84,7 @@ export default class ColorHeatmap extends React.Component {
       const colors = this.props.colors || (
         (valueDomain.length == 2) ?
           ['#000000', '#ffffff'] :
-          _.times(valueDomain.length, d3.scale.category10().domain(_.range(10)))
+          _.times(valueDomain.length, scale.schemeCategory10().domain(_.range(10)))
       );
       colorScale = makeColorScale(valueDomain, colors, interpolator);
     }

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -26,12 +26,6 @@ function makeColorScale(domain, colors, interpolator) {
   if(_.isString(interpolator))
     interpolator = interpolatorFromType(interpolator);
 
-  // const interp = scaleLinear()
-  //   .domain(domain)
-  //   .range(colors);
-
-  debugger;
-
   return scaleLinear()
     .domain(domain)
     .range(colors)

--- a/src/FunnelChart.js
+++ b/src/FunnelChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import {area, scaleOrdinal, schemeCategory20b} from 'd3';
 import invariant from 'invariant';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -46,21 +46,25 @@ export default class FunnelChart extends React.Component {
   render() {
     const {data, scale, getX, getY, horizontal} = this.props;
 
-    const area = d3.svg.area()
-      .x(d => scale.x(makeAccessor(getX)(d)))
-      .y(d => scale.y(makeAccessor(getY)(d)));
+    const funnelArea = area();
+    if(horizontal) {
+      funnelArea
+        .x0(d => scale.x(-makeAccessor(getX)(d)))
+        .x1(d => scale.x(makeAccessor(getX)(d)))
+        .y(d => scale.y(makeAccessor(getY)(d)));
+    } else {
+      funnelArea
+        .x(d => scale.x(makeAccessor(getX)(d)))
+        .y0(d => scale.y(-makeAccessor(getY)(d)))
+        .y1(d => scale.y(makeAccessor(getY)(d)));
+    }
 
-    if(horizontal)
-      area.x0(d => scale.x(-makeAccessor(getX)(d)));
-    else
-      area.y0(d => scale.y(-makeAccessor(getY)(d)));
-
-    const colors = d3.scale.category20b().domain(_.range(10));
+    const colors = scaleOrdinal(schemeCategory20b).domain(_.range(10));
 
     return <g className="funnel-chart">
       {data.map((d, i) => {
         if(i == 0) return null;
-        const pathStr = area([data[i-1], d]);
+        const pathStr = funnelArea([data[i-1], d]);
 
         return <path d={pathStr} style={{fill: colors(i-1), stroke: 'transparent'}} />;
       })}

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {histogram} from 'd3-array';
 
 import AreaBarChart from './AreaBarChart';
 
@@ -24,12 +24,12 @@ export default class Histogram extends React.Component {
   }
 
   componentWillMount() {
-    const histogram = d3.histogram()
+    const histogramGenerator = histogram()
       .domain(this.props.domain.x)
       .thresholds(30);
 
     // why is `histogram` returning an array of length 40+ when it should be exactly 30???
-    const histogramData = histogram(this.props.data);
+    const histogramData = histogramGenerator(this.props.data);
 
     this.setState({histogramData});
   }

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -24,8 +24,13 @@ export default class Histogram extends React.Component {
   }
 
   componentWillMount() {
-    const histogramData = d3.layout.histogram().bins(30)(this.props.data);
-    //console.log('histogram', this.props.data, histogramData);
+    const histogram = d3.histogram()
+      .domain(this.props.domain.x)
+      .thresholds(30);
+
+    // why is `histogram` returning an array of length 40+ when it should be exactly 30???
+    const histogramData = histogram(this.props.data);
+
     this.setState({histogramData});
   }
 
@@ -35,9 +40,9 @@ export default class Histogram extends React.Component {
 
     return <AreaBarChart
       data={this.state.histogramData}
-      getX="x"
-      getXEnd={d => d.x + d.dx}
-      getY="y"
+      getX={d => d.x0}
+      getXEnd={d => d.x1}
+      getY={d => d.length}
       {...{name, scale, axisType, scaleWidth, scaleHeight, plotWidth, plotHeight}}
     />;
   }

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {histogram} from 'd3-array';
+import {histogram} from 'd3';
 
 import AreaBarChart from './AreaBarChart';
 

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -2,14 +2,18 @@ import React from 'react';
 import _ from 'lodash';
 import {histogram} from 'd3';
 
+import * as CustomPropTypes from './utils/CustomPropTypes';
+import {makeAccessor, domainFromRangeData} from './utils/Data';
 import AreaBarChart from './AreaBarChart';
 
+// todo make histogram work horizontally *or* vertically
 export default class Histogram extends React.Component {
   static propTypes = {
     // the array of data objects
     data: React.PropTypes.array.isRequired,
-    // accessor for X & Y coordinates
-    getValue: React.PropTypes.object,
+    // accessors for X & Y coordinates
+    getValue: CustomPropTypes.getter,
+
     axisType: React.PropTypes.object,
     scale: React.PropTypes.object
   };
@@ -24,12 +28,14 @@ export default class Histogram extends React.Component {
   }
 
   componentWillMount() {
-    const histogramGenerator = histogram()
-      .domain(this.props.domain.x)
+    const {domain, getValue, data} = this.props;
+    const chartHistogram = histogram()
+      .domain(domain.x)
+      // todo - get this working with arbitrary getValue accessor - seems to be broken -DD
+      .value(makeAccessor(getValue))
       .thresholds(30);
 
-    // why is `histogram` returning an array of length 40+ when it should be exactly 30???
-    const histogramData = histogramGenerator(this.props.data);
+    const histogramData = chartHistogram(data);
 
     this.setState({histogramData});
   }

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import AreaBarChart from './AreaBarChart';
 

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {mean} from 'd3-array';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
 import LineChart from './LineChart.js';
@@ -75,7 +75,7 @@ class KernelDensityEstimation extends React.Component {
 function kernelDensityEstimator(kernel, x) {
   return function(sample) {
     return x.map(function(x) {
-      return [x, d3.mean(sample, function(v) { return kernel(x - v); })];
+      return [x, mean(sample, function(v) { return kernel(x - v); })];
     });
   };
 }

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {mean} from 'd3-array';
+import {mean} from 'd3';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
 import LineChart from './LineChart.js';

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import * as CustomPropTypes from './utils/CustomPropTypes';
 import LineChart from './LineChart.js';

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {bisector} from 'd3-array';
 import shallowEqual from './utils/shallowEqual';
 
 import {makeAccessor} from './utils/Data';
@@ -52,7 +52,7 @@ export default class LineChart extends React.Component {
   // }
 
   initBisector(props) {
-    this.setState({bisectX: d3.bisector(d => makeAccessor(props.getX)(d)).left});
+    this.setState({bisectX: bisector(d => makeAccessor(props.getX)(d)).left});
   }
 
   getHovered = (x, y) => {

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {bisector} from 'd3-array';
+import {bisector} from 'd3';
 import shallowEqual from './utils/shallowEqual';
 
 import {makeAccessor} from './utils/Data';

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import shallowEqual from './utils/shallowEqual';
 
 import {makeAccessor} from './utils/Data';

--- a/src/MarkerLineChart.js
+++ b/src/MarkerLineChart.js
@@ -1,7 +1,6 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/MarkerLineChart.js
+++ b/src/MarkerLineChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/PieChart.js
+++ b/src/PieChart.js
@@ -1,7 +1,6 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/PieChart.js
+++ b/src/PieChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {methodIfFuncProp} from './util.js';
 import {makeAccessor} from './utils/Data';

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {makeAccessor} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {treemap} from 'd3-hierarchy';
 
 import {makeAccessor} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -155,19 +155,19 @@ function initTreemapLayout(options) {
   // and configure it with the given options
   const {width, height, getValue, getChildren, sort, padding, round, sticky, mode, ratio} = options;
 
-  const treemap = d3.layout.treemap()
+  const treemapLayout = treemap()
     .size([width, height])
     .value(makeAccessor(getValue));
 
-  if(!_.isUndefined(getChildren)) treemap.children(makeAccessor(getChildren));
-  if(!_.isUndefined(sort)) treemap.sort(sort);
-  if(!_.isUndefined(padding)) treemap.padding(padding);
-  if(!_.isUndefined(round)) treemap.round(round);
-  if(!_.isUndefined(sticky)) treemap.sticky(sticky);
-  if(!_.isUndefined(mode)) treemap.mode(mode);
-  if(!_.isUndefined(ratio)) treemap.ratio(ratio);
+  if(!_.isUndefined(getChildren)) treemapLayout.children(makeAccessor(getChildren));
+  if(!_.isUndefined(sort)) treemapLayout.sort(sort);
+  if(!_.isUndefined(padding)) treemapLayout.padding(padding);
+  if(!_.isUndefined(round)) treemapLayout.round(round);
+  if(!_.isUndefined(sticky)) treemapLayout.sticky(sticky);
+  if(!_.isUndefined(mode)) treemapLayout.mode(mode);
+  if(!_.isUndefined(ratio)) treemapLayout.ratio(ratio);
 
-  return treemap;
+  return treemapLayout;
 }
 
 export default TreeMap;

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import {treemap} from 'd3';
+import {hierarchy, treemap} from 'd3-hierarchy';
 
 import {makeAccessor} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';
@@ -34,14 +34,14 @@ class TreeMapNode extends React.Component {
   render() {
     const {node, getLabel, nodeStyle, labelStyle, minLabelWidth, minLabelHeight, NodeLabelComponent, parentNames}
       = this.props;
-    const {x, y, dx, dy, depth, parent} = node;
+    const {depth, parent, x0, y0, x1, y1} = node;
 
     const nodeGroupClass = parent ?
       `node-group-${_.kebabCase(parent.name)} node-group-i-${parentNames.indexOf(parent.name)}` : '';
     const className = `tree-map-node node-depth-${depth} ${nodeGroupClass}`;
 
-    let style = {position: 'absolute', width: dx, height: dy, top: y, left: x};
-    const customStyle = _.isFunction(nodeStyle) ? nodeStyle(node) : (_.isObject(nodeStyle) ? nodeStyle : {});
+    let style = {position: 'absolute', width: (x1 - x0), height: (y1 - y0), top: y0, left: x0};
+    const customStyle = _.isFunction(nodeStyle) ? nodeStyle(node.data) : (_.isObject(nodeStyle) ? nodeStyle : {});
     _.assign(style, customStyle);
 
     let handlers = ['onClick', 'onMouseEnter', 'onMouseLeave', 'onMouseMove'].reduce((handlers, eventName) => {
@@ -51,7 +51,7 @@ class TreeMapNode extends React.Component {
     }, {});
 
     return <div {...{className, style}} {...handlers}>
-      {dx > minLabelWidth && dy > minLabelHeight ? // show label if node is big enough
+      {(x1 - x0) > minLabelWidth && (y1 - y0) > minLabelHeight ? // show label if node is big enough
         <NodeLabelComponent {...{node, getLabel, labelStyle}} />
         : null
       }
@@ -70,14 +70,13 @@ class TreeMapNodeLabel extends React.Component {
 
   render() {
     const {node, getLabel, labelStyle} = this.props;
-    const {x, y, dx, dy} = node;
-
-    let style = {width: dx};
+    const {x1, x0} = node;
+    let style = {width: (x1 - x0)};
     const customStyle = _.isFunction(labelStyle) ? labelStyle(node) : (_.isObject(labelStyle) ? labelStyle : {});
     _.assign(style, customStyle);
 
     return <div className="node-label" {...{style}}>
-      {makeAccessor(getLabel)(node)}
+      {makeAccessor(getLabel)(node.data)}
     </div>
   }
 }
@@ -131,10 +130,8 @@ class TreeMap extends React.Component {
 
     // clone the data because d3 mutates it!
     const data = _.cloneDeep(this.props.data);
-    // initialize the layout function
-    const treemap = initTreemapLayout(this.props);
-    // run the layout function with our data to create treemap layout
-    const nodes = treemap.nodes(data);
+    // // initialize the layout function
+    const nodes = initTreemapLayout(this.props);
 
     const style = {position: 'relative', width, height};
 
@@ -153,13 +150,12 @@ class TreeMap extends React.Component {
 function initTreemapLayout(options) {
   // create a d3 treemap layout function,
   // and configure it with the given options
-  const {width, height, getValue, getChildren, sort, padding, round, sticky, mode, ratio} = options;
+  const {data, width, height, getValue, getChildren, sort, padding, round, sticky, mode, ratio} = options;
 
-  const treemapLayout = treemap()
-    .size([width, height])
-    .value(makeAccessor(getValue));
+  const rootNode = hierarchy(data, makeAccessor(getChildren)).sum(d => d[getValue] || 0);
+  const tree = treemap().size([width, height]);
+  const treemapLayout = tree(rootNode).descendants();
 
-  if(!_.isUndefined(getChildren)) treemapLayout.children(makeAccessor(getChildren));
   if(!_.isUndefined(sort)) treemapLayout.sort(sort);
   if(!_.isUndefined(padding)) treemapLayout.padding(padding);
   if(!_.isUndefined(round)) treemapLayout.round(round);

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import {treemap} from 'd3-hierarchy';
+import {treemap} from 'd3';
 
 import {makeAccessor} from './utils/Data';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-import * as d3 from 'd3';
 
 import resolveObjectProps from './utils/resolveObjectProps';
 import resolveXYScales from './utils/resolveXYScales';

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import resolveObjectProps from './utils/resolveObjectProps';
 import resolveXYScales from './utils/resolveXYScales';

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -13,6 +13,14 @@ function indexOfClosestNumberInList(number, list) {
   }, 0);
 }
 
+function invertPointScale(scale, rangeValue) {
+  // shim until d3.scalePoint.invert() is implemented for real
+  // given a value from the output range, returns the *nearest* corresponding value in the input domain
+  const rangePoints = scale.domain().map(domainValue => scale(domainValue));
+  const nearestPointIndex = indexOfClosestNumberInList(rangeValue, rangePoints);
+  return scale.domain()[nearestPointIndex];
+}
+
 function getMouseOptions(event, {scale, height, width, margin}) {
   const chartBB = event.currentTarget.getBoundingClientRect();
   const outerX = Math.round(event.clientX - chartBB.left);
@@ -24,11 +32,11 @@ function getMouseOptions(event, {scale, height, width, margin}) {
 
   const xValue = (!_.inRange(innerX, 0, chartSize.width /* + padding.left + padding.right */)) ? null :
     (scaleType.x === 'ordinal') ?
-      scale.x.domain()[indexOfClosestNumberInList(innerX, scale.x.range())] :
+      invertPointScale(scale.x, innerX) :
       scale.x.invert(innerX);
   const yValue = (!_.inRange(innerY, 0, chartSize.height /* + padding.top + padding.bottom */)) ? null :
     (scaleType.y === 'ordinal') ?
-      scale.y.domain()[indexOfClosestNumberInList(innerY, scale.y.range())] :
+      invertPointScale(scale.y, innerY) :
       scale.y.invert(innerY);
 
   return {event, outerX, outerY, innerX, innerY, xValue, yValue, scale, margin};

--- a/src/old/BarChart.js
+++ b/src/old/BarChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {accessor, AccessorPropType, InterfaceMixin, methodIfFuncProp} from './util.js';
 

--- a/src/old/XYPlot.js
+++ b/src/old/XYPlot.js
@@ -1,7 +1,7 @@
 import React from 'react';
 //const {PropTypes} = React;
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import {accessor} from '../util.js';
 import moment from 'moment';
 import numeral from 'numeral';

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {extent} from 'd3-array';
+import {extent} from 'd3';
 import React from 'react';
 
 /**

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 import React from 'react';
 
 /**

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {extent} from 'd3-array';
 import React from 'react';
 
 /**
@@ -86,13 +86,13 @@ export function combineDomains(domains, dataType) {
   if(!_.isArray(domains)) return undefined;
   return (dataType === 'categorical') ?
     _.uniq(_.flatten(_.compact(domains))) :
-    d3.extent(_.flatten(domains));
+    extent(_.flatten(domains));
 }
 
 export function domainFromData(data, accessor = _.identity, type = undefined) {
   if(!type) type = inferDataType(data, accessor);
   return (type === 'number' || type === 'time') ?
-    d3.extent(data.map(accessor)) :
+    extent(data.map(accessor)) :
     _.uniq(data.map(accessor));
 }
 
@@ -114,9 +114,9 @@ export function domainFromRangeData(data, rangeStartAccessor, rangeEndAccessor, 
   switch(dataType) {
     case 'number':
     case 'time':
-      return d3.extent(_.flatten([
-        d3.extent(data, (d, i) => +rangeStartAccessor(d, i)),
-        d3.extent(data, (d, i) => +rangeEndAccessor(d, i))
+      return extent(_.flatten([
+        extent(data, (d, i) => +rangeStartAccessor(d, i)),
+        extent(data, (d, i) => +rangeEndAccessor(d, i))
       ]));
     case 'categorical':
       return _.uniq(_.flatten([data.map(rangeStartAccessor), data.map(rangeEndAccessor)]));

--- a/src/utils/Margin.js
+++ b/src/utils/Margin.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 export const zeroMargin = {top: 0, bottom: 0, left: 0, right: 0};
 

--- a/src/utils/Margin.js
+++ b/src/utils/Margin.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
 
 export const zeroMargin = {top: 0, bottom: 0, left: 0, right: 0};
 

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import * as d3 from 'd3';
+import {scaleLinear, scaleTime, scaleOrdinal, scaleLog, scalePow} from 'd3-scale';
 
 import {combineDomains, domainFromData} from './Data';
 
@@ -42,11 +42,11 @@ export function inferScaleType(scale) {
 
 export function initScale(scaleType) {
   switch(scaleType) {
-    case 'linear': return d3.scaleLinear();
-    case 'time': return d3.scaleTime();
-    case 'ordinal': return d3.scaleOrdinal();
-    case 'log': return d3.scaleLog();
-    case 'pow': return d3.scalePow();
+    case 'linear': return scaleLinear();
+    case 'time': return scaleTime();
+    case 'ordinal': return scaleOrdinal();
+    case 'log': return scaleLog();
+    case 'pow': return scalePow();
   }
 }
 

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import {scaleLinear, scaleTime, scaleOrdinal, scaleLog, scalePow} from 'd3';
+import {scaleLinear, scaleTime, scalePoint, scaleLog, scalePow} from 'd3';
 
 import {combineDomains, domainFromData} from './Data';
 
@@ -44,7 +44,7 @@ export function initScale(scaleType) {
   switch(scaleType) {
     case 'linear': return scaleLinear();
     case 'time': return scaleTime();
-    case 'ordinal': return scaleOrdinal();
+    case 'ordinal': return scalePoint();
     case 'log': return scaleLog();
     case 'pow': return scalePow();
   }

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import d3 from 'd3';
+import * as d3 from 'd3';
 
 import {combineDomains, domainFromData} from './Data';
 
@@ -42,11 +42,11 @@ export function inferScaleType(scale) {
 
 export function initScale(scaleType) {
   switch(scaleType) {
-    case 'linear': return d3.scale.linear();
-    case 'time': return d3.time.scale();
-    case 'ordinal': return d3.scale.ordinal();
-    case 'log': return d3.scale.log();
-    case 'pow': return d3.scale.pow();
+    case 'linear': return d3.scaleLinear();
+    case 'time': return d3.scaleTime();
+    case 'ordinal': return d3.scaleOrdinal();
+    case 'log': return d3.scaleLog();
+    case 'pow': return d3.scalePow();
   }
 }
 

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import {scaleLinear, scaleTime, scaleOrdinal, scaleLog, scalePow} from 'd3-scale';
+import {scaleLinear, scaleTime, scaleOrdinal, scaleLog, scalePow} from 'd3';
 
 import {combineDomains, domainFromData} from './Data';
 

--- a/src/utils/resolveXYScales.js
+++ b/src/utils/resolveXYScales.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import * as d3 from 'd3';
 import React from 'react';
 import invariant from 'invariant';
 
@@ -356,12 +357,15 @@ export default function resolveXYScales(ComposedComponent) {
         if(hasScaleFor(scale, k)) return [k, scale[k]];
 
         // create scale from domain/range
+        // PM/ER December 19, 2016 - Unsure whether or not this is the best approach.
+        //                           Importing d3 in this file also seems wrong. Graphs render correctly.
+        let kScale;
         const rangeMethod = (scaleType[k] === 'ordinal') ? 'rangePoints' : 'range';
-        const kScale = initScale(scaleType[k])
-          .domain(domain[k])[rangeMethod](range[k]);
-
-
-
+        if (scaleType[k] === 'ordinal') {
+          kScale = d3.scalePoint().domain(domain[k]).range(range[k]);
+        } else {
+          kScale = initScale(scaleType[k]).domain(domain[k])[rangeMethod](range[k]);
+        }
 
         // todo - ticks, nice and getDomain should be an axis prop instead, and axis should have getDomain
 

--- a/src/utils/resolveXYScales.js
+++ b/src/utils/resolveXYScales.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import {scalePoint} from 'd3-scale';
 import React from 'react';
 import invariant from 'invariant';
 
@@ -362,7 +362,7 @@ export default function resolveXYScales(ComposedComponent) {
         let kScale;
         const rangeMethod = (scaleType[k] === 'ordinal') ? 'rangePoints' : 'range';
         if (scaleType[k] === 'ordinal') {
-          kScale = d3.scalePoint().domain(domain[k]).range(range[k]);
+          kScale = scalePoint().domain(domain[k]).range(range[k]);
         } else {
           kScale = initScale(scaleType[k]).domain(domain[k])[rangeMethod](range[k]);
         }

--- a/src/utils/resolveXYScales.js
+++ b/src/utils/resolveXYScales.js
@@ -357,15 +357,7 @@ export default function resolveXYScales(ComposedComponent) {
         if(hasScaleFor(scale, k)) return [k, scale[k]];
 
         // create scale from domain/range
-        // PM/ER December 19, 2016 - Unsure whether or not this is the best approach.
-        //                           Importing d3 in this file also seems wrong. Graphs render correctly.
-        let kScale;
-        const rangeMethod = (scaleType[k] === 'ordinal') ? 'rangePoints' : 'range';
-        if (scaleType[k] === 'ordinal') {
-          kScale = scalePoint().domain(domain[k]).range(range[k]);
-        } else {
-          kScale = initScale(scaleType[k]).domain(domain[k])[rangeMethod](range[k]);
-        }
+        const kScale = initScale(scaleType[k]).domain(domain[k]).range(range[k]);
 
         // todo - ticks, nice and getDomain should be an axis prop instead, and axis should have getDomain
 

--- a/src/utils/resolveXYScales.js
+++ b/src/utils/resolveXYScales.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {scalePoint} from 'd3-scale';
+import {scalePoint} from 'd3';
 import React from 'react';
 import invariant from 'invariant';
 


### PR DESCRIPTION
Upgrades d3 to version 4.4.0 and performs the necessary syntax changes.

Todo:
- [x] Histogram (needs more work, but now matches old functionality with d3 v4)
- [x] Funnel Chart
- [x] Import only what's required per chart type (e.g.: `import {scaleLinear} from 'd3-scale'` instead of `import * as d3 from 'd3'`
- [x] Custom Chart Children (mouse events not working correctly)  - TODO in future - d3.scalePoint.invert proposal
- [x] Treemap
