### PR TITLE
Updates to AreaChart, new util function for combining datasets

### DIFF
--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1309,9 +1309,41 @@ class Area2DatasetsExample extends React.Component {
     return <div>
       <XYPlot width={600}>
         <XAxis tickCount={4}/><YAxis/>
+        <AreaChart data={combined} getX='x' getY='y0' getYEnd='y1' />
         <LineChart data={data1} getX="x" getY="y"/>
         <LineChart data={data2} getX="x" getY="y"/>
-        <AreaChart data={combined} getX='x' getY='y0' getYEnd='y1' />
+      </XYPlot>
+    </div>
+  }
+}
+
+class AreaDifferenceExample extends React.Component {
+  render() {
+    const data1 = randomWalkTimeSeries(115).map(([x, y]) => ({x, y}));
+    const data2 = randomWalkTimeSeries(115).map(([x, y]) => ({x, y}));
+
+    // we have two datasets, but AreaChart takes one combined dataset
+    // so combine the two datasets into one using the combineDatasets utility function
+    const combined = combineDatasets([
+      {data: data1, combineKey: 'x', dataKeys: {y: 'y0'}},
+      {data: data2, combineKey: 'x', dataKeys: {y: 'y1'}}
+    ], 'x');
+
+    return <div>
+      <XYPlot width={600}>
+        <XAxis tickCount={4}/><YAxis/>
+
+        <AreaChart
+          data={combined}
+          isDifference={true}
+          pathStyleNegative={{fill: 'lightcoral'}}
+          pathStylePositive={{fill: 'lightgreen'}}
+          getX='x'
+          getY='y0'
+          getYEnd='y1'
+        />
+        <LineChart data={data1} getX="x" getY="y" lineStyle={{strokeWidth: 3}}/>
+        <LineChart data={data2} getX="x" getY="y" />
       </XYPlot>
     </div>
   }
@@ -1345,6 +1377,8 @@ export const examples = [
   {id: 'multipleXY', title: 'Multiple Chart Types', Component: MultipleXYExample},
   {id: 'spacing', title: 'Spacing', Component: SpacingExample},
   {id: 'area2datasets', title: 'Area Chart w/ 2 datasets', Component: Area2DatasetsExample},
+  {id: 'areaDifference', title: 'Area Difference Chart', Component: AreaDifferenceExample},
+
   // todo rewrite these?
   // {id: 'customTicks', title: 'Custom Axis Ticks', Component: CustomTicksExample},
   // {id: 'customAxisLabels', title: 'Custom Axis Labels', Component: CustomAxisLabelsExample},

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -1288,6 +1288,36 @@ class SpacingExample extends React.Component {
   }
 }
 
+class Area2DatasetsExample extends React.Component {
+  render() {
+    const data1 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
+    const data2 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
+
+    // remove some random data points (ie. add gaps) to make sure it still combines them correctly
+    const gapData1 = removeRandomData(data1, 5);
+    const gapData2 = removeRandomData(data2, 5);
+
+    // we have two datasets, but AreaChart takes one combined dataset
+    // so combine the two datasets into one using the combineDatasets utility function
+    // original datasets are of the shape [{x: ..., y: 20}]
+    // combined is of the shape [{x: ..., y0: 20, y1: 30}]
+    const combined = combineDatasets([
+      {data: gapData1, combineKey: 'x', dataKeys: {y: 'y0'}},
+      {data: gapData2, combineKey: 'x', dataKeys: {y: 'y1'}}
+    ], 'x');
+
+    return <div>
+      <XYPlot width={600}>
+        <XAxis tickCount={4}/><YAxis/>
+        <LineChart data={data1} getX="x" getY="y"/>
+        <LineChart data={data2} getX="x" getY="y"/>
+        <AreaChart data={combined} getX='x' getY='y0' getYEnd='y1' />
+      </XYPlot>
+    </div>
+  }
+}
+
+
 export const examples = [
   {id: 'line', title: 'Line Chart', Component: LineChartExample},
   {id: 'line2', title: 'Interactive Line Chart', Component: LineChartExample2},
@@ -1319,35 +1349,6 @@ export const examples = [
   // {id: 'customTicks', title: 'Custom Axis Ticks', Component: CustomTicksExample},
   // {id: 'customAxisLabels', title: 'Custom Axis Labels', Component: CustomAxisLabelsExample},
 ];
-
-class Area2DatasetsExample extends React.Component {
-  render() {
-    const data1 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
-    const data2 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
-
-    // remove some random data points (ie. add gaps) to make sure it still combines them correctly
-    const gapData1 = removeRandomData(data1, 5);
-    const gapData2 = removeRandomData(data2, 5);
-
-    // we have two datasets, but AreaChart takes one combined dataset
-    // so combine the two datasets into one using the combineDatasets utility function
-    // original datasets are of the shape [{x: ..., y: 20}]
-    // combined is of the shape [{x: ..., y0: 20, y1: 30}]
-    const combined = combineDatasets([
-      {data: gapData1, combineKey: 'x', dataKeys: {y: 'y0'}},
-      {data: gapData2, combineKey: 'x', dataKeys: {y: 'y1'}}
-    ], 'x');
-
-    return <div>
-      <XYPlot width={600}>
-        <XAxis tickCount={4}/><YAxis/>
-        <LineChart data={data1} getX="x" getY="y"/>
-        <LineChart data={data2} getX="x" getY="y"/>
-        <AreaChart data={combined} getX='x' getY='y0' getYEnd='y1' />
-      </XYPlot>
-    </div>
-  }
-}
 
 export const App = React.createClass({
   getInitialState() {

--- a/examples/src/Examples.jsx
+++ b/examples/src/Examples.jsx
@@ -40,7 +40,9 @@ import KernelDensityEstimation from '../../src/KernelDensityEstimation';
 
 import AreaChart from '../../src/AreaChart';
 
-import {randomWalk, randomWalkSeries} from './data/util';
+import {randomWalk, randomWalkSeries, randomWalkTimeSeries, removeRandomData} from './data/util';
+
+import {combineDatasets} from '../../src/utils/Data';
 
 // sample ordinal data
 const ordinalData = ['Always', 'Usually', 'Sometimes', 'Rarely', 'Never'];
@@ -1311,12 +1313,41 @@ export const examples = [
   {id: 'barMarkerLine', title: 'Bar Charts with Marker Lines', Component: BarMarkerLineExample},
   {id: 'customChildren', title: 'Custom Chart Children', Component: CustomChildExample},
   {id: 'multipleXY', title: 'Multiple Chart Types', Component: MultipleXYExample},
-  {id: 'spacing', title: 'Spacing', Component: SpacingExample}
+  {id: 'spacing', title: 'Spacing', Component: SpacingExample},
+  {id: 'area2datasets', title: 'Area Chart w/ 2 datasets', Component: Area2DatasetsExample},
   // todo rewrite these?
   // {id: 'customTicks', title: 'Custom Axis Ticks', Component: CustomTicksExample},
   // {id: 'customAxisLabels', title: 'Custom Axis Labels', Component: CustomAxisLabelsExample},
 ];
 
+class Area2DatasetsExample extends React.Component {
+  render() {
+    const data1 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
+    const data2 = randomWalkTimeSeries(115).map(([x,y]) => ({x, y}));
+
+    // remove some random data points (ie. add gaps) to make sure it still combines them correctly
+    const gapData1 = removeRandomData(data1, 5);
+    const gapData2 = removeRandomData(data2, 5);
+
+    // we have two datasets, but AreaChart takes one combined dataset
+    // so combine the two datasets into one using the combineDatasets utility function
+    // original datasets are of the shape [{x: ..., y: 20}]
+    // combined is of the shape [{x: ..., y0: 20, y1: 30}]
+    const combined = combineDatasets([
+      {data: gapData1, combineKey: 'x', dataKeys: {y: 'y0'}},
+      {data: gapData2, combineKey: 'x', dataKeys: {y: 'y1'}}
+    ], 'x');
+
+    return <div>
+      <XYPlot width={600}>
+        <XAxis tickCount={4}/><YAxis/>
+        <LineChart data={data1} getX="x" getY="y"/>
+        <LineChart data={data2} getX="x" getY="y"/>
+        <AreaChart data={combined} getX='x' getY='y0' getYEnd='y1' />
+      </XYPlot>
+    </div>
+  }
+}
 
 export const App = React.createClass({
   getInitialState() {
@@ -1333,7 +1364,6 @@ export const App = React.createClass({
   render() {
     return <div>
       <h1>Reactochart Examples</h1>
-
       {this.renderExamples()}
     </div>
   },

--- a/examples/src/data/util.js
+++ b/examples/src/data/util.js
@@ -1,11 +1,29 @@
 import _ from 'lodash';
 
 export function randomWalk(length=100, start=0, variance=10) {
-    return _.reduce(_.range(length-1), (sequence, i) => {
-        return sequence.concat(_.last(sequence) + _.random(-variance, variance));
-    }, [start]);
+  return _.reduce(_.range(length-1), (sequence, i) => {
+    return sequence.concat(_.last(sequence) + _.random(-variance, variance));
+  }, [start]);
 }
 
 export function randomWalkSeries(length=100, start=0, variance=10) {
-    return randomWalk(length, start, variance).map((n,i) => [i,n]);
+  return randomWalk(length, start, variance).map((n,i) => [i,n]);
+}
+
+export function randomWalkTimeSeries(length=100, start=0, variance=10, startDate=new Date(2015, 0, 1)) {
+  let date = startDate;
+  return randomWalk(length, start, variance).map((n, i) => {
+    date = new Date(date.getTime() + (24 * 60 * 60 * 1000));
+    return [date, n];
+  });
+}
+
+export function removeRandomData(data, removeCount = 5) {
+  const gapData = data.slice();
+  _.times(removeCount, () => {
+    if(!gapData.length) return;
+    const gapIndex = _.random(gapData.length - 1);
+    gapData.splice(gapIndex, 1);
+  });
+  return gapData;
 }


### PR DESCRIPTION
Due to the way d3 works, the `AreaChart` component requires a single combined dataset - but sometimes you have two separate datasets which need a shaded area between them. This adds a utility function called `combineDatasets`, which users can use to combine their multiple datasets into a single one with multiple keys, before passing it into the `AreaChart`.

Also adds props called `shouldShowGaps` and `isDefined` which allow users to decide whether or not to represent undefined data as gaps in the area chart (`shouldShowGaps`), and if so, how the chart should determine whether a given datum is defined or undefined (`isDefined` function, which runs on each datum).

Also adds an example showing how to use these features.