### PR TITLE
Fix for non-string SankeyDiagram nodeLabelText prop

### DIFF
--- a/tests/jsdom/spec/SankeyDiagram.spec.js
+++ b/tests/jsdom/spec/SankeyDiagram.spec.js
@@ -610,7 +610,7 @@ describe("SankeyDiagram", () => {
       id: "lemons",
       name: "Sour Lemons"
     };
-    it("renders a node label", () => {
+    it("renders a node label in a <text> element", () => {
       const label = mount(<SankeyNodeLabel {...{node: basicNodeObj, nodeLabelText: () => "ok"}} />);
       const text = label.find("text");
       expect(text).to.have.length(1);
@@ -643,6 +643,20 @@ describe("SankeyDiagram", () => {
       expect(textWithId).to.have.length(1);
       expect(textWithId.text()).to.equal("lemons");
     });
+    it("renders nodeLabelText as-is (not wrapped in <text>), if it returns an element instead of string", () => {
+      const label = mount(
+        <SankeyNodeLabel
+          {...{
+            node: basicNodeObj,
+            nodeLabelText: node => <rect x={node.x0} y={node.y0} width={50} height={20} />
+          }}
+        />
+      );
+      expect(label.find("text")).to.have.length(0);
+      expect(label.find("rect")).to.have.length(1);
+      expect(label.find("rect").props().width).to.equal(50);
+    });
+
     it("passes nodeLabelClassName and nodeLabelStyle through to the text element", () => {
       const nodeLabelClassName = "my-fun-node-label";
       const nodeLabelStyle = {fill: "salmon"};


### PR DESCRIPTION
Starting in v0.4.2 we allowed the `SankeyDiagram` `nodeLabelText` prop to return an arbitrary HTML element (as opposed to a string) in order to support custom labels which are more complicated than a single text string. These were rendered inside a `<foreignObject>` tag which was positioned using a `translate` transform which attempted to follow all node placement rules and allow the user to use HTML instead of SVG text.

However, @krissalvador27 noticed that positioning of these labels was broken in Chrome when the `SankeyDiagram` is inside of a `ZoomContainer`. Further investigation revealed that Chrome's support for `<foreignObject>` is rather poor, likely due to issues Webkit (see eg. Webkit issues [71819](https://bugs.webkit.org/show_bug.cgi?id=71819) and [93358](https://bugs.webkit.org/show_bug.cgi?id=93358)).

The most flexible fix for this is to simplify our handling of these custom labels and render them as arbitrary SVG elements instead of `<foreignObject>`s. This still allows the user to render `<foreignObject>`s on their own, if they want to figure out the placement issues, but takes the responsibility for this positioning out of the hands of Reactochart.