### PR TITLE
Add offset prop to x and y labels

### DIFF
--- a/src/XAxis.js
+++ b/src/XAxis.js
@@ -58,6 +58,10 @@ export default class XAxis extends React.Component {
     labelFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     labelFormats: PropTypes.array,
     labels: PropTypes.array,
+    /**
+     * Adds horizontal offset to the y axis labels
+     */
+    labelOffset: PropTypes.number,
 
     tickLength: PropTypes.number,
     tickClassName: PropTypes.string,

--- a/src/XAxis.js
+++ b/src/XAxis.js
@@ -59,7 +59,7 @@ export default class XAxis extends React.Component {
     labelFormats: PropTypes.array,
     labels: PropTypes.array,
     /**
-     * Adds horizontal offset to the y axis labels
+     * Adds horizontal offset (along the XAxis) to the labels
      */
     labelOffset: PropTypes.number,
 

--- a/src/XAxisLabels.js
+++ b/src/XAxisLabels.js
@@ -166,9 +166,14 @@ class XAxisLabels extends React.Component {
     /**
      * `mouseleave` event handler callback, called when user's mouse leaves the label.
      */
-    onMouseLeaveLabel: PropTypes.func
+    onMouseLeaveLabel: PropTypes.func,
+    /**
+     * Adds horizontal offset to the labels
+     */
+    offset: PropTypes.func
   };
   static defaultProps = {
+    offset: 0,
     height: 250,
     position: "bottom",
     placement: undefined,
@@ -287,7 +292,8 @@ class XAxisLabels extends React.Component {
       onMouseMoveLabel,
       onMouseLeaveLabel,
       spacingTop,
-      spacingBottom
+      spacingBottom,
+      offset
     } = this.props;
     const labels = this.props.labels || XAxisLabels.getLabels(this.props);
     const placement =
@@ -303,7 +309,7 @@ class XAxisLabels extends React.Component {
     return (
       <g className="rct-chart-value-labels-x" transform={transform}>
         {labels.map((label, i) => {
-          const x = xScale(label.value);
+          const x = xScale(label.value) + offset;
           const y = placement === "above" ? -label.height - distance : distance;
           const [onMouseEnter, onMouseMove, onMouseLeave] = [
             "onMouseEnterLabel",

--- a/src/XAxisLabels.js
+++ b/src/XAxisLabels.js
@@ -168,7 +168,7 @@ class XAxisLabels extends React.Component {
      */
     onMouseLeaveLabel: PropTypes.func,
     /**
-     * Adds horizontal offset to the labels
+     * Adds horizontal offset (along the XAxis) to the labels
      */
     offset: PropTypes.func
   };

--- a/src/YAxis.js
+++ b/src/YAxis.js
@@ -59,7 +59,7 @@ export default class YAxis extends React.Component {
     labelFormats: PropTypes.array,
     labels: PropTypes.array,
     /**
-     * Adds vertical offset to the y axis labels
+     * Adds vertical offset (along the YAxis) to the labels
      */
     labelOffset: PropTypes.number,
 

--- a/src/YAxis.js
+++ b/src/YAxis.js
@@ -58,6 +58,10 @@ export default class YAxis extends React.Component {
     labelFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     labelFormats: PropTypes.array,
     labels: PropTypes.array,
+    /**
+     * Adds vertical offset to the y axis labels
+     */
+    labelOffset: PropTypes.number,
 
     tickLength: PropTypes.number,
     tickClassName: PropTypes.string,

--- a/src/YAxisLabels.js
+++ b/src/YAxisLabels.js
@@ -135,9 +135,15 @@ class YAxisLabels extends React.Component {
      * height - height of the given label
      * width - width of the given label
      */
-    labels: PropTypes.array
+    labels: PropTypes.array,
+    /**
+     * Adds vertical offset to the labels
+     */
+    offset: PropTypes.number
   };
+
   static defaultProps = {
+    offset: 0,
     height: 250,
     width: 400,
     position: "left",
@@ -255,7 +261,8 @@ class YAxisLabels extends React.Component {
       onMouseMoveLabel,
       onMouseLeaveLabel,
       spacingLeft,
-      spacingRight
+      spacingRight,
+      offset
     } = this.props;
     const placement =
       this.props.placement || (position === "left" ? "before" : "after");
@@ -275,7 +282,7 @@ class YAxisLabels extends React.Component {
     return (
       <g className="rct-chart-value-labels-y" transform={transform}>
         {labels.map((label, i) => {
-          const y = yScale(label.value);
+          const y = yScale(label.value) + offset;
           const x = placement === "before" ? -distance : distance;
 
           const [onMouseEnter, onMouseMove, onMouseLeave] = [

--- a/src/YAxisLabels.js
+++ b/src/YAxisLabels.js
@@ -137,7 +137,7 @@ class YAxisLabels extends React.Component {
      */
     labels: PropTypes.array,
     /**
-     * Adds vertical offset to the labels
+     * Adds vertical offset (along the YAxis) to the labels
      */
     offset: PropTypes.number
   };

--- a/src/utils/Axis.js
+++ b/src/utils/Axis.js
@@ -25,6 +25,7 @@ export function getAxisChildProps(props) {
     labelStyle,
     labelFormat,
     labelFormats,
+    labelOffset,
     labels,
     gridLineClassName,
     gridLineStyle,
@@ -85,6 +86,7 @@ export function getAxisChildProps(props) {
     distance: labelDistance,
     format: labelFormat,
     formats: labelFormats,
+    offset: labelOffset,
     onMouseEnterLabel,
     onMouseMoveLabel,
     onMouseLeaveLabel

--- a/tests/browser/spec/XAxisLabels.spec.js
+++ b/tests/browser/spec/XAxisLabels.spec.js
@@ -19,7 +19,8 @@ describe("XAxisLabel", () => {
     marginTop: 11,
     marginBottom: 22,
     marginLeft: 33,
-    marginRight: 44
+    marginRight: 44,
+    offset: 5
   };
 
   it("Check how many labels are created and where", () => {

--- a/tests/browser/spec/YAxisLabels.spec.js
+++ b/tests/browser/spec/YAxisLabels.spec.js
@@ -19,7 +19,8 @@ describe("YAxisLabel", () => {
     marginTop: 11,
     marginBottom: 22,
     marginLeft: 33,
-    marginRight: 44
+    marginRight: 44,
+    offset: 5
   };
 
   it("Check how many labels are created and where", () => {

--- a/tests/jsdom/spec/utils.Axis.spec.js
+++ b/tests/jsdom/spec/utils.Axis.spec.js
@@ -33,6 +33,7 @@ describe("Axis utils", () => {
       labelFormats: ["0a"],
       labels: ["what a label"],
       gridLineClassName: "my-grid",
+      labelOffset: 10,
       gridLineStyle: { stroke: "blue" },
       onMouseEnterLabel: () => {},
       onMouseMoveLabel: () => {},
@@ -114,7 +115,8 @@ describe("Axis utils", () => {
         {
           distance: axisProps.labelDistance,
           format: axisProps.labelFormat,
-          formats: axisProps.labelFormats
+          formats: axisProps.labelFormats,
+          offset: axisProps.labelOffset
         }
       )
     );


### PR DESCRIPTION
This adds offset to the x and y labels. This sets up use cases like so
<img width="326" alt="screen shot 2018-08-28 at 4 03 43 pm" src="https://user-images.githubusercontent.com/5139481/44747807-0a788e00-aadc-11e8-9b0e-e32c353dbc67.png">
