### PR TITLE
[bug] fix xyPlotClassName omission

### DIFF
--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -229,6 +229,7 @@ class XYPlot extends React.Component {
       spacingLeft,
       spacingRight,
       style,
+      xyPlotClassName,
       // Passed in as prop from resolveXYScales
       xScale,
       yScale


### PR DESCRIPTION
Fix a regression with the property translation to variable being omitted