### PR TITLE
Add limit props to set height and width of XLine and YLine respectively

### DIFF
--- a/docs/src/docs/XLine/propDocs.json
+++ b/docs/src/docs/XLine/propDocs.json
@@ -16,6 +16,27 @@
       "required": true,
       "description": ""
     },
+    "yScale": {
+      "type": {
+        "name": "func"
+      },
+      "required": false,
+      "description": "D3 scale for Y axis - provided by XYPlot"
+    },
+    "yLimit": {
+      "type": {
+        "name": "any"
+      },
+      "required": false,
+      "description": "Limit on the height of the line"
+    },
+    "yDomain": {
+      "type": {
+        "name": "array"
+      },
+      "required": false,
+      "description": "Y domain of the data as an array - provided by XYPlot"
+    },
     "spacingTop": {
       "type": {
         "name": "number"

--- a/docs/src/docs/YLine/propDocs.json
+++ b/docs/src/docs/YLine/propDocs.json
@@ -16,6 +16,20 @@
       "required": true,
       "description": ""
     },
+    "xScale": {
+      "type": {
+        "name": "func"
+      },
+      "required": false,
+      "description": "D3 scale for X axis - provided by XYPlot"
+    },
+    "xLimit": {
+      "type": {
+        "name": "any"
+      },
+      "required": false,
+      "description": "Limit on the width of the line"
+    },
     "spacingLeft": {
       "type": {
         "name": "number"

--- a/src/XLine.js
+++ b/src/XLine.js
@@ -12,6 +12,15 @@ export default class XLine extends React.Component {
     xScale: PropTypes.func,
     value: PropTypes.any.isRequired,
     /**
+     * D3 scale for Y axis - provided by XYPlot
+     */
+    yScale: PropTypes.func,
+    yLimit: PropTypes.any,
+    /**
+     * The Y domain of the data as an array - provided by XYPlot
+     */
+    yDomain: PropTypes.array,
+    /**
      * Spacing top - provided by XYPlot
      */
     spacingTop: PropTypes.number,
@@ -39,6 +48,9 @@ export default class XLine extends React.Component {
     const {
       xScale,
       value,
+      yScale,
+      yLimit,
+      yDomain,
       height,
       style,
       spacingTop,
@@ -47,13 +59,21 @@ export default class XLine extends React.Component {
     const className = `rct-chart-line-x ${this.props.className}`;
     const lineX = xScale(value);
 
+    let y1 = -spacingTop;
+    let y2 = height + spacingBottom;
+
+    if (yLimit) {
+      y1 = yScale(yDomain[0]);
+      y2 = yScale(yLimit);
+    }
+
     return (
       <line
         {...{
           x1: lineX,
           x2: lineX,
-          y1: -spacingTop,
-          y2: height + spacingBottom,
+          y1: y1,
+          y2: y2,
           className,
           style
         }}

--- a/src/XLine.js
+++ b/src/XLine.js
@@ -62,8 +62,8 @@ export default class XLine extends React.Component {
     let y1 = -spacingTop;
     let y2 = height + spacingBottom;
 
-    if (yLimit) {
-      y1 = yScale(yDomain[0]);
+    if (typeof yLimit !== "undefined") {
+      y1 = yScale(yDomain[0]) + spacingBottom;
       y2 = yScale(yLimit);
     }
 

--- a/src/YLine.js
+++ b/src/YLine.js
@@ -12,6 +12,11 @@ export default class YLine extends React.Component {
     yScale: PropTypes.func,
     value: PropTypes.any.isRequired,
     /**
+     * D3 scale for X axis - provided by XYPlot
+     */
+    xScale: PropTypes.func,
+    xLimit: PropTypes.any,
+    /**
      * Spacing left - provided by XYPlot
      */
     spacingLeft: PropTypes.number,
@@ -39,6 +44,8 @@ export default class YLine extends React.Component {
     const {
       yScale,
       value,
+      xScale,
+      xLimit,
       width,
       spacingLeft,
       spacingRight,
@@ -46,12 +53,14 @@ export default class YLine extends React.Component {
     } = this.props;
     const className = `rct-chart-line-y ${this.props.className || ""}`;
     const lineY = yScale(value);
+    const lineX =
+      typeof xLimit === "undefined" ? width + spacingRight : xScale(xLimit);
 
     return (
       <line
         {...{
           x1: -spacingLeft,
-          x2: width + spacingRight,
+          x2: lineX,
           y1: lineY,
           y2: lineY,
           className,

--- a/tests/jsdom/spec/XLine.spec.js
+++ b/tests/jsdom/spec/XLine.spec.js
@@ -110,4 +110,20 @@ describe("XLine", () => {
     );
     expect(findLine(wrapper).prop("style")).to.deep.equal(style);
   });
+
+  it("limits the line's height using yLimit", () => {
+    const limit = 2;
+    let wrapper = shallow(
+      <XLine 
+        yScale={linearScale}
+        xScale={linearScale}
+        yDomain={linearScale.domain}
+        value={linearValue}
+        yLimit={limit}
+        {...commonProps}
+      />
+    );
+    expect(getLineHeight(findLine(wrapper))).to.equal(linearScale(limit));
+  });
+
 });

--- a/tests/jsdom/spec/YLine.spec.js
+++ b/tests/jsdom/spec/YLine.spec.js
@@ -110,4 +110,19 @@ describe("YLine", () => {
     );
     expect(findLine(wrapper).prop("style")).to.deep.equal(style);
   });
+
+  it("limits the line's width using xLimit", () => {
+    const limit = 2;
+    let wrapper = shallow(
+      <YLine 
+        yScale={linearScale}
+        xScale={linearScale}
+        value={linearValue}
+        xLimit={limit}
+        {...commonProps}
+      />
+    );
+    expect(getLineWidth(findLine(wrapper))).to.equal(linearScale(limit));
+  });
+
 });


### PR DESCRIPTION
Adds the height/width limit props discussed in #149 

<img width="1142" alt="Screen Shot 2019-06-10 at 3 41 10 AM" src="https://user-images.githubusercontent.com/14301342/59181856-e2977a00-8b85-11e9-8f60-ed51af71c780.png">
<img width="1142" alt="Screen Shot 2019-06-10 at 3 40 43 AM" src="https://user-images.githubusercontent.com/14301342/59181858-e2977a00-8b85-11e9-8a43-53c660fb3ed0.png">
