### PR TITLE
Deprecate moment in favor of d3 time format

### DIFF
--- a/docs/src/ExampleSection.js
+++ b/docs/src/ExampleSection.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import _ from "lodash";
-import moment from "moment";
 import * as d3 from "d3";
 import Playground from "component-playground";
 
@@ -12,8 +11,7 @@ import * as Reactochart from "../../src";
 import {
   randomWalk,
   randomWalkSeries,
-  randomWalkTimeSeries,
-  removeRandomData
+  randomWalkTimeSeries
 } from "./data/util";
 window.Reactochart = Reactochart;
 
@@ -55,7 +53,6 @@ export default class ExampleSection extends React.Component {
       ReactDOM,
       d3,
       _,
-      moment,
       randomWalk,
       randomWalkSeries,
       randomWalkTimeSeries,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactochart",
-  "version": "1.12.0-rc.0",
+  "version": "1.12.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10300,11 +10300,6 @@
           }
         }
       }
-    },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moo": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "d3-sankey": "^0.12.1",
     "invariant": "^2.2.0",
     "lodash": "^4.17.15",
-    "moment": "^2.10.6",
     "numeral": "^2.0.6",
     "prop-types": "^15.5.10",
     "units-css": "^0.4.0"

--- a/src/XAxisLabels.js
+++ b/src/XAxisLabels.js
@@ -6,7 +6,6 @@ import max from "lodash/max";
 import capitalize from "lodash/capitalize";
 import get from "lodash/get";
 import isFunction from "lodash/isFunction";
-import identity from "lodash/identity";
 import PropTypes from "prop-types";
 import React from "react";
 import MeasuredValueLabel from "./MeasuredValueLabel";
@@ -15,7 +14,8 @@ import {
   countRangeOverlaps,
   getLabelsXOverhang,
   getLabelXRange,
-  makeLabelFormatters
+  makeLabelFormatters,
+  getDefaultFormats
 } from "./utils/Label";
 import { getValue } from "./utils/Data";
 import { getScaleTicks, getTickDomain, inferScaleType } from "./utils/Scale";
@@ -262,24 +262,6 @@ class XAxisLabels extends React.Component {
     );
   }
 
-  static getDefaultFormats(scaleType) {
-    const timeFormatStrs = ["YYYY", "'YY", "MMM YYYY", "M/YY"];
-    const numberFormatStrs = [
-      "0.[00]a",
-      "0,0",
-      "0.[0]",
-      "0.[00]",
-      "0.[0000]",
-      "0.[000000]"
-    ];
-
-    return scaleType === "ordinal"
-      ? [identity]
-      : scaleType === "time"
-        ? timeFormatStrs
-        : numberFormatStrs;
-  }
-
   static getLabels(props) {
     const { tickCount, labelStyle, xScale } = defaults(
       props,
@@ -297,7 +279,7 @@ class XAxisLabels extends React.Component {
     const formatStrs =
       Array.isArray(propsFormats) && propsFormats.length
         ? propsFormats
-        : XAxisLabels.getDefaultFormats(scaleType);
+        : getDefaultFormats(scaleType);
     const formats = makeLabelFormatters(formatStrs, scaleType);
 
     // todo resolve ticks also

--- a/src/YAxisLabels.js
+++ b/src/YAxisLabels.js
@@ -5,14 +5,14 @@ import max from "lodash/max";
 import capitalize from "lodash/capitalize";
 import get from "lodash/get";
 import isFunction from "lodash/isFunction";
-import identity from "lodash/identity";
 import PropTypes from "prop-types";
 import React from "react";
 import MeasuredValueLabel from "./MeasuredValueLabel";
 import {
   checkLabelsDistinct,
   getLabelsYOverhang,
-  makeLabelFormatters
+  makeLabelFormatters,
+  getDefaultFormats
 } from "./utils/Label";
 import { getValue } from "./utils/Data";
 import { getScaleTicks, getTickDomain, inferScaleType } from "./utils/Scale";
@@ -234,24 +234,6 @@ class YAxisLabels extends React.Component {
     );
   }
 
-  static getDefaultFormats(scaleType) {
-    const timeFormatStrs = ["YYYY", "'YY", "MMM YYYY", "M/YY"];
-    const numberFormatStrs = [
-      "0.[00]a",
-      "0,0",
-      "0.[0]",
-      "0.[00]",
-      "0.[0000]",
-      "0.[000000]"
-    ];
-
-    return scaleType === "ordinal"
-      ? [identity]
-      : scaleType === "time"
-        ? timeFormatStrs
-        : numberFormatStrs;
-  }
-
   static getLabels(props) {
     const { tickCount, labelStyle, yScale } = defaults(
       props,
@@ -268,7 +250,7 @@ class YAxisLabels extends React.Component {
     const formatStrs =
       Array.isArray(propsFormats) && propsFormats.length
         ? propsFormats
-        : YAxisLabels.getDefaultFormats(scaleType);
+        : getDefaultFormats(scaleType);
     const formats = makeLabelFormatters(formatStrs, scaleType);
 
     // todo resolve ticks also

--- a/src/utils/Label.js
+++ b/src/utils/Label.js
@@ -5,14 +5,36 @@ import tail from "lodash/tail";
 import min from "lodash/min";
 import max from "lodash/max";
 import reduce from "lodash/reduce";
-import moment from "moment";
 import numeral from "numeral";
+import { timeFormat } from "d3";
+
+export function getDefaultFormats(scaleType) {
+  const defaultTimeFormats = ["%Y", "'%y", "%b %Y", "%m/%Y"];
+  const defaultNumberFormats = [
+    "0.[00]a",
+    "0,0",
+    "0.[0]",
+    "0.[00]",
+    "0.[0000]",
+    "0.[000000]"
+  ];
+
+  return scaleType === "ordinal"
+    ? [identity]
+    : scaleType === "time"
+      ? defaultTimeFormats
+      : defaultNumberFormats;
+}
 
 export function makeLabelFormatters(formatStrs, scaleType) {
   return formatStrs.map(formatStr => {
     if (!isString(formatStr)) return formatStr;
     return scaleType === "time"
-      ? v => moment(v).format(formatStr)
+      ? v => {
+          const timeFormatter = timeFormat(formatStr);
+
+          return timeFormatter(v);
+        }
       : v => numeral(v).format(formatStr);
   });
 }

--- a/tests/browser/spec/XAxisLabels.spec.js
+++ b/tests/browser/spec/XAxisLabels.spec.js
@@ -9,20 +9,6 @@ chai.use(sinonChai);
 // XAxisLabels tests must run in browser since XAxisLabels uses measureText
 
 describe("XAxisLabel", () => {
-  const width = 500;
-  const height = 300;
-  const props = {
-    width,
-    height,
-    xScaleType: "linear",
-    yScaleType: "linear",
-    marginTop: 11,
-    marginBottom: 22,
-    marginLeft: 33,
-    marginRight: 44,
-    offset: 5
-  };
-
   it("Check how many labels are created and where", () => {
     const chartStyle = { marginBottom: "10px" };
     const functions = {
@@ -117,6 +103,46 @@ describe("XAxisLabel", () => {
         expect(expectedStyles[styleKey]).to.equal(styleValue);
       });
 
+      return textContent;
+    });
+
+    expect(renderedTickLabels).to.eql(correctTickLabels);
+  });
+
+  it("Renders date labels given formats array", () => {
+    const tree = (
+      <XYPlot
+        width={400}
+        height={150}
+        xDomain={[new Date("01/01/2015"), new Date("01/01/2019")]}
+        yDomain={[-20, 20]}
+      >
+        <XAxisLabels
+          formats={["%B %d, %Y", "%m/%Y"]}
+          position="top"
+          distance={2}
+          tickCount={5}
+        />
+      </XYPlot>
+    );
+
+    const rendered = mount(tree).find(XAxisLabels);
+    const labelWrapper = rendered.first("g");
+    const labels = labelWrapper.children().find("text");
+
+    // Logic should pick the "%m/%Y" format since "%B %d, %Y"
+    // which would format the labels like so January 30, 2015, would have too many collisions when rendered
+    const correctTickLabels = [
+      "01/2015",
+      "01/2016",
+      "01/2017",
+      "01/2018",
+      "01/2019"
+    ];
+
+    const renderedTickLabels = labels.map(label => {
+      const instance = label.instance();
+      const textContent = instance.textContent;
       return textContent;
     });
 

--- a/tests/browser/spec/YAxisLabels.spec.js
+++ b/tests/browser/spec/YAxisLabels.spec.js
@@ -122,4 +122,46 @@ describe("YAxisLabel", () => {
 
     expect(renderedTickLabels).to.eql(correctTickLabels);
   });
+
+  it("Renders date labels given formats array", () => {
+    const tree = (
+      <XYPlot
+        width={400}
+        height={150}
+        yDomain={[new Date("01/01/2015"), new Date("01/01/2019")]}
+        xDomain={[-20, 20]}
+      >
+        <YAxisLabels
+          formats={["%B %d, %Y", "%m/%Y"]}
+          position="top"
+          distance={2}
+          tickCount={5}
+        />
+      </XYPlot>
+    );
+
+    const rendered = mount(tree).find(YAxisLabels);
+    const labelWrapper = rendered.first("g");
+    const labels = labelWrapper.children().find("text");
+
+    // Logic should pick our first format "%B %d, %Y"
+    // which would format the labels like so January 30, 2015
+    // because YAxisLabels (rendered vertically) wouldn't have collisions
+    const correctTickLabels = [
+      "January 01, 2015",
+      "January 01, 2016",
+      "January 01, 2017",
+      "January 01, 2018",
+      "January 01, 2019"
+    ];
+
+    const renderedTickLabels = labels.map(label => {
+      const instance = label.instance();
+      const textContent = instance.textContent;
+      console.log(textContent);
+      return textContent;
+    });
+
+    expect(renderedTickLabels).to.eql(correctTickLabels);
+  });
 });


### PR DESCRIPTION
Deprecates moment in favor of d3 time format. This is a breaking change because the `formats` array passed into `XAxisLabels` and `YAxisLabels` accepted moment's format strings when handling date types, as opposed to d3 time format which uses [strptime and strftime](https://github.com/d3/d3-time-format#locale_format). 

These changes will be merged into the `2.0.0-rc.0` branch.

Addresses issue #158 