### PR TITLE
Fix children proptype for YAxisTitle

### DIFF
--- a/src/YAxisTitle.js
+++ b/src/YAxisTitle.js
@@ -40,7 +40,7 @@ export default class YAxisTitle extends React.Component {
      */
     spacingRight: PropTypes.number,
     title: PropTypes.string,
-    children: PropTypes.string,
+    children: PropTypes.any,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Fixes proptype warning for YAxisTitle if passing in something other than a string