### PR TITLE
Decorate XYPlot onMouseEnter and onMouseLeave events

### DIFF
--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -211,9 +211,8 @@ class XYPlot extends React.Component {
   onMouseDown = this.onXYMouseEvent.bind(this, 'onMouseDown');
   onMouseUp = this.onXYMouseEvent.bind(this, 'onMouseUp');
   onClick = this.onXYMouseEvent.bind(this, 'onClick');
-
-  onMouseEnter = event => this.props.onMouseEnter({ event });
-  onMouseLeave = event => this.props.onMouseLeave({ event });
+  onMouseEnter = this.onXYMouseEvent.bind(this, 'onMouseEnter');
+  onMouseLeave = this.onXYMouseEvent.bind(this, 'onMouseLeave')
 
   render() {
     const {


### PR DESCRIPTION
- Created a binding declaration for the onMouseEnter and onMouseLeave events similar to the onClick, onMouseDown etc. events for XYPlot
- Removed original declaration of onMouseEnter and onMouseLeave events
- Closes #176