### PR TITLE
Fix xy plot lesson in docs

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -13,7 +13,9 @@ const lessons = [
     Component: Lessons.QuickStartLesson,
   },
   { name: 'XY Plots', path: '/xy-plots', Component: Lessons.XYPlotsLesson },
+  // TODO lesson needs to be cleaned up, see lessons/GettersAndAccessors
   // {name: "Getters & Accessors", path: '/getters-and-accessors', Component: Lessons.GettersAndAccessorsLesson},
+  // TODO lesson needs to be cleaned up, see lessons/Interaction
   // {name: "Interaction", path: '/interaction', Component: Lessons.InteractionLesson},
 ];
 

--- a/docs/src/lessons/GettersAndAccessors/GettersAndAccessorsLesson.js
+++ b/docs/src/lessons/GettersAndAccessors/GettersAndAccessorsLesson.js
@@ -93,7 +93,9 @@ export default class GettersAndAccessorsLesson extends React.Component {
         <ExampleSection
           id="basic"
           label="Getter Usage Example"
-          codeText={require('./examples/GettersAndAccessors.js.example')}
+          codeText={
+            require('./examples/GettersAndAccessors.js.example').default
+          }
         />
 
         <p>
@@ -111,7 +113,7 @@ export default class GettersAndAccessorsLesson extends React.Component {
         <ExampleSection
           id="basic"
           label="Graphing Calculator Example"
-          codeText={require('./examples/GraphingCalculator.js.example')}
+          codeText={require('./examples/GraphingCalculator.js.example').default}
         />
       </Lesson>
     );

--- a/docs/src/lessons/XYPlots/XYPlotsLesson.js
+++ b/docs/src/lessons/XYPlots/XYPlotsLesson.js
@@ -33,7 +33,7 @@ export default class XYPlotsLesson extends React.Component {
         <ExampleSection
           id="basic"
           label="XYPlot and LineChart"
-          codeText={require('./examples/LineChart.js.example')}
+          codeText={require('./examples/LineChart.js.example').default}
         />
 
         <p>
@@ -58,7 +58,7 @@ export default class XYPlotsLesson extends React.Component {
         <ExampleSection
           id="lineChartWithAxis"
           label="LineChart with axes"
-          codeText={require('./examples/LineChartWithAxis.js.example')}
+          codeText={require('./examples/LineChartWithAxis.js.example').default}
         />
 
         <p>
@@ -79,7 +79,7 @@ export default class XYPlotsLesson extends React.Component {
         <ExampleSection
           id="multiChart"
           label="Multiple Charts in one XYPlot"
-          codeText={require('./examples/MultiChart.js.example')}
+          codeText={require('./examples/MultiChart.js.example').default}
         />
       </Lesson>
     );


### PR DESCRIPTION
Reported by @scottsheffield, the XYPlot lesson in the docs is showing a blank page. The bug and corresponding fix is related to the raw-loader upgrade here https://github.com/spotify/reactochart/pull/195/commits/c817b5be821564334cb777771a381a6d37464b17