### PR TITLE
Rename upcoming deprecated Lifecycle methods

### DIFF
--- a/docs/src/docs/PieChart/examples/PieChart.js.example
+++ b/docs/src/docs/PieChart/examples/PieChart.js.example
@@ -11,7 +11,7 @@ class PieChartExample extends React.Component {
     this.setState({ sinVal });
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._interval = setInterval(this._animateValue, 20);
   }
   componentWillUnmount() {

--- a/docs/src/docs/TreeMap/examples/AnimatedTreeMap.js.example
+++ b/docs/src/docs/TreeMap/examples/AnimatedTreeMap.js.example
@@ -8,7 +8,7 @@ class AnimatedTreeMapExample extends React.Component {
       this.setState({getValue: "size"});
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._interval = setInterval(this._animateValue, 1000);
     this._data = {
       children: _.range(1, 5).map(n => ({

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -71,10 +71,10 @@ class KernelDensityEstimation extends React.Component {
     return shouldUpdate;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.initKDE(this.props);
   }
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     this.initKDE(newProps);
   }
   initKDE(props) {

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -17,32 +17,25 @@ export default class LineChart extends React.Component {
     data: PropTypes.array.isRequired,
     /**
      * Accessor function for line X values, called once per datum, or a single value to be used for the entire line.
-     */
-    x: CustomPropTypes.valueOrAccessor,
+     */ x: CustomPropTypes.valueOrAccessor,
     /**
      * Accessor function for line Y values, called once per datum, or a single value to be used for the entire line.
-     */
-    y: CustomPropTypes.valueOrAccessor,
+     */ y: CustomPropTypes.valueOrAccessor,
     /**
      * Inline style object to be applied to the line path.
-     */
-    lineStyle: PropTypes.object,
+     */ lineStyle: PropTypes.object,
     /**
      * Class attribute to be applied to the line path.
-     */
-    lineClassName: PropTypes.string,
+     */ lineClassName: PropTypes.string,
     /**
      * D3 scale for X axis - provided by XYPlot.
-     */
-    xScale: PropTypes.func,
+     */ xScale: PropTypes.func,
     /**
      * D3 scale for Y axis - provided by XYPlot.
-     */
-    yScale: PropTypes.func,
+     */ yScale: PropTypes.func,
     /**
      * D3 curve for path generation
-     */
-    curve: PropTypes.func,
+     */ curve: PropTypes.func,
   };
   static defaultProps = {
     lineStyle: {},
@@ -54,11 +47,13 @@ export default class LineChart extends React.Component {
     return !xyPropsEqual(this.props, nextProps, ['lineStyle', 'lineClassName']);
   }
 
-  componentWillMount() {
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillMount() {
     this.initBisector(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.initBisector(nextProps);
   }
 

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -17,25 +17,32 @@ export default class LineChart extends React.Component {
     data: PropTypes.array.isRequired,
     /**
      * Accessor function for line X values, called once per datum, or a single value to be used for the entire line.
-     */ x: CustomPropTypes.valueOrAccessor,
+     */
+    x: CustomPropTypes.valueOrAccessor,
     /**
      * Accessor function for line Y values, called once per datum, or a single value to be used for the entire line.
-     */ y: CustomPropTypes.valueOrAccessor,
+     */
+    y: CustomPropTypes.valueOrAccessor,
     /**
      * Inline style object to be applied to the line path.
-     */ lineStyle: PropTypes.object,
+     */
+    lineStyle: PropTypes.object,
     /**
      * Class attribute to be applied to the line path.
-     */ lineClassName: PropTypes.string,
+     */
+    lineClassName: PropTypes.string,
     /**
      * D3 scale for X axis - provided by XYPlot.
-     */ xScale: PropTypes.func,
+     */
+    xScale: PropTypes.func,
     /**
      * D3 scale for Y axis - provided by XYPlot.
-     */ yScale: PropTypes.func,
+     */
+    yScale: PropTypes.func,
     /**
      * D3 curve for path generation
-     */ curve: PropTypes.func,
+     */
+    curve: PropTypes.func,
   };
   static defaultProps = {
     lineStyle: {},

--- a/src/SankeyDiagram.js
+++ b/src/SankeyDiagram.js
@@ -976,11 +976,13 @@ export default class SankeyDiagram extends React.Component {
     this._graph = enhanceGraph(sankeyGraph);
   }
 
-  componentWillMount() {
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillMount() {
     this._makeSankeyGraph();
   }
 
-  componentWillReceiveProps(nextProps) {
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // only update this._graph if a prop which affects the sankey layout has changed (most don't)
     const sankeyLayoutPropKeys = [
       'nodes',

--- a/src/TreeMap.js
+++ b/src/TreeMap.js
@@ -106,14 +106,18 @@ class TreeMap extends React.Component {
     NodeComponent: TreeMapNode,
     NodeLabelComponent: TreeMapNodeLabel,
   };
-  componentWillMount() {
+
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillMount() {
     const { data } = this.props;
     // initialize the layout function
     this._tree = getTree(this.props);
     // clone the data because d3 mutates it!
     this._rootNode = getRootNode(cloneDeep(data), this.props);
   }
-  componentWillReceiveProps(newProps) {
+
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillReceiveProps(newProps) {
     const { width, height, data, sticky } = this.props;
 
     // if height, width, or the data changes, or if the treemap is not sticky, re-initialize the layout function

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -23,92 +23,75 @@ export default class ZoomContainer extends React.Component {
     width: PropTypes.number,
     /**
      * (outer) width of the chart (SVG element).
-     */
-    height: PropTypes.number,
+     */ height: PropTypes.number,
     /**
      * Zoom callback function, called when zoom changes.
      * For controlled version of this component, you should update zoomX, zoomY and zoomScale props in this callback.
-     */
-    onZoom: PropTypes.func,
+     */ onZoom: PropTypes.func,
     /**
      * Boolean which determines whether the component is "controlled" (true) or "stateful" (false).
      * When true, zoom transformation is controlled entirely by the `zoomX`, `zoomY` and `zoomScale` props, which
      * you are responsible for updating in the `onZoom` callback function.
      * When false, zoom transformation is handled by internal state, and the `zoomX`, `zoomY` and `zoomScale` props
      * specify only the initial X, Y and scale transformation of the component.
-     */
-    controlled: PropTypes.bool,
+     */ controlled: PropTypes.bool,
     /**
      * Disables wheel-driven zooming (say to not interfere with native scrolling).
-     */
-    disableMouseWheelZoom: PropTypes.bool,
+     */ disableMouseWheelZoom: PropTypes.bool,
     /**
      * The X-coordinate of the zoom transformation (or initial X-coordinate, if `controlled` is false).
-     */
-    zoomX: PropTypes.number,
+     */ zoomX: PropTypes.number,
     /**
      * The Y-coordinate of the zoom transformation (or initial Y-coordinate, if `controlled` is false).
-     */
-    zoomY: PropTypes.number,
+     */ zoomY: PropTypes.number,
     /**
      * The scaling factor of the zoom transformation (or initial scaling, if `controlled` is false).
      * 1.0 is normal size, 2.0 is double size, 0.5 is half size.
-     */
-    zoomScale: PropTypes.number,
+     */ zoomScale: PropTypes.number,
     /**
      * Sets the viewport extent to the specified array of points [[x0, y0], [x1, y1]],
      * where [x0, y0] is the top-left corner of the viewport and [x1, y1] is the bottom-right corner of the viewport.
      * See d3-zoom docs for more information.
-     */
-    extent: PropTypes.array,
+     */ extent: PropTypes.array,
     /**
      * Sets the scale extent to the specified array of numbers [k0, k1]
      * where k0 is the minimum allowed scale factor and k1 is the maximum allowed scale factor.
      * See d3-zoom docs for more information.
-     */
-    scaleExtent: PropTypes.array,
+     */ scaleExtent: PropTypes.array,
     /**
      * Sets the translate extent to the specified array of points [[x0, y0], [x1, y1]],
      * where [x0, y0] is the top-left corner of the world and [x1, y1] is the bottom-right corner of the world.
      * See d3-zoom docs for more information.
-     */
-    translateExtent: PropTypes.array,
+     */ translateExtent: PropTypes.array,
     /**
      * Sets the maximum distance that the mouse can move between mousedown and mouseup that will trigger
      * a subsequent click event.
      * See d3-zoom docs for more information.
-     */
-    clickDistance: PropTypes.number,
+     */ clickDistance: PropTypes.number,
     /**
      * Sets the duration for zoom transitions on double-click and double-tap to the specified number of milliseconds.
      * See d3-zoom docs for more information.
-     */
-    duration: PropTypes.number,
+     */ duration: PropTypes.number,
     /**
      * Sets the interpolation factory for zoom transitions to the specified function.
      * See d3-zoom docs for more information.
-     */
-    interpolate: PropTypes.func,
+     */ interpolate: PropTypes.func,
     /**
      * Sets the transform constraint function to the specified function.
      * See d3-zoom docs for more information.
-     */
-    constrain: PropTypes.func,
+     */ constrain: PropTypes.func,
     /**
      * Sets the zoom event filter to the specified function.
      * See d3-zoom docs for more information.
-     */
-    filter: PropTypes.func,
+     */ filter: PropTypes.func,
     /**
      * Sets the touch support detector to the specified function.
      * See d3-zoom docs for more information.
-     */
-    touchable: PropTypes.func,
+     */ touchable: PropTypes.func,
     /**
      * Sets the wheel delta function to the specified function.
      * See d3-zoom docs for more information.
-     */
-    wheelDelta: PropTypes.func,
+     */ wheelDelta: PropTypes.func,
     children: PropTypes.any,
   };
   static defaultProps = {
@@ -167,9 +150,8 @@ export default class ZoomContainer extends React.Component {
     if (this.props.onZoom) this.props.onZoom(nextZoomTransform, ...args);
   };
 
-  // React is deprecating componentWillReceiveProps, but it's pretty much necessary in this case
-  // TODO: change to UNSAFE_componentWillReceiveProps when upgrading React
-  componentWillReceiveProps(nextProps) {
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.controlled) {
       // if controlled component and zoom props have changed, apply the new zoom props to d3-zoom
       // (unbind handler first so as not to create infinite callback loop)

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -23,75 +23,92 @@ export default class ZoomContainer extends React.Component {
     width: PropTypes.number,
     /**
      * (outer) width of the chart (SVG element).
-     */ height: PropTypes.number,
+     */
+    height: PropTypes.number,
     /**
      * Zoom callback function, called when zoom changes.
      * For controlled version of this component, you should update zoomX, zoomY and zoomScale props in this callback.
-     */ onZoom: PropTypes.func,
+     */
+    onZoom: PropTypes.func,
     /**
      * Boolean which determines whether the component is "controlled" (true) or "stateful" (false).
      * When true, zoom transformation is controlled entirely by the `zoomX`, `zoomY` and `zoomScale` props, which
      * you are responsible for updating in the `onZoom` callback function.
      * When false, zoom transformation is handled by internal state, and the `zoomX`, `zoomY` and `zoomScale` props
      * specify only the initial X, Y and scale transformation of the component.
-     */ controlled: PropTypes.bool,
+     */
+    controlled: PropTypes.bool,
     /**
      * Disables wheel-driven zooming (say to not interfere with native scrolling).
-     */ disableMouseWheelZoom: PropTypes.bool,
+     */
+    disableMouseWheelZoom: PropTypes.bool,
     /**
      * The X-coordinate of the zoom transformation (or initial X-coordinate, if `controlled` is false).
-     */ zoomX: PropTypes.number,
+     */
+    zoomX: PropTypes.number,
     /**
      * The Y-coordinate of the zoom transformation (or initial Y-coordinate, if `controlled` is false).
-     */ zoomY: PropTypes.number,
+     */
+    zoomY: PropTypes.number,
     /**
      * The scaling factor of the zoom transformation (or initial scaling, if `controlled` is false).
      * 1.0 is normal size, 2.0 is double size, 0.5 is half size.
-     */ zoomScale: PropTypes.number,
+     */
+    zoomScale: PropTypes.number,
     /**
      * Sets the viewport extent to the specified array of points [[x0, y0], [x1, y1]],
      * where [x0, y0] is the top-left corner of the viewport and [x1, y1] is the bottom-right corner of the viewport.
      * See d3-zoom docs for more information.
-     */ extent: PropTypes.array,
+     */
+    extent: PropTypes.array,
     /**
      * Sets the scale extent to the specified array of numbers [k0, k1]
      * where k0 is the minimum allowed scale factor and k1 is the maximum allowed scale factor.
      * See d3-zoom docs for more information.
-     */ scaleExtent: PropTypes.array,
+     */
+    scaleExtent: PropTypes.array,
     /**
      * Sets the translate extent to the specified array of points [[x0, y0], [x1, y1]],
      * where [x0, y0] is the top-left corner of the world and [x1, y1] is the bottom-right corner of the world.
      * See d3-zoom docs for more information.
-     */ translateExtent: PropTypes.array,
+     */
+    translateExtent: PropTypes.array,
     /**
      * Sets the maximum distance that the mouse can move between mousedown and mouseup that will trigger
      * a subsequent click event.
      * See d3-zoom docs for more information.
-     */ clickDistance: PropTypes.number,
+     */
+    clickDistance: PropTypes.number,
     /**
      * Sets the duration for zoom transitions on double-click and double-tap to the specified number of milliseconds.
      * See d3-zoom docs for more information.
-     */ duration: PropTypes.number,
+     */
+    duration: PropTypes.number,
     /**
      * Sets the interpolation factory for zoom transitions to the specified function.
      * See d3-zoom docs for more information.
-     */ interpolate: PropTypes.func,
+     */
+    interpolate: PropTypes.func,
     /**
      * Sets the transform constraint function to the specified function.
      * See d3-zoom docs for more information.
-     */ constrain: PropTypes.func,
+     */
+    constrain: PropTypes.func,
     /**
      * Sets the zoom event filter to the specified function.
      * See d3-zoom docs for more information.
-     */ filter: PropTypes.func,
+     */
+    filter: PropTypes.func,
     /**
      * Sets the touch support detector to the specified function.
      * See d3-zoom docs for more information.
-     */ touchable: PropTypes.func,
+     */
+    touchable: PropTypes.func,
     /**
      * Sets the wheel delta function to the specified function.
      * See d3-zoom docs for more information.
-     */ wheelDelta: PropTypes.func,
+     */
+    wheelDelta: PropTypes.func,
     children: PropTypes.any,
   };
   static defaultProps = {


### PR DESCRIPTION
`componentWillReceiveProps` => `UNSAFE_componentWillReceiveProps`
`componentWillUpdate` => `UNSAFE_componentWillUpdate`

Apparently in React 17.x these will continue to work 🎉 but also they're still unsafe 😒 

addresses #181 