### PR TITLE
Remove deprecated Lifecycle hooks

### DIFF
--- a/docs/src/docs/PieChart/examples/PieChart.js.example
+++ b/docs/src/docs/PieChart/examples/PieChart.js.example
@@ -11,7 +11,7 @@ class PieChartExample extends React.Component {
     this.setState({ sinVal });
   };
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this._interval = setInterval(this._animateValue, 20);
   }
   componentWillUnmount() {

--- a/docs/src/docs/TreeMap/examples/AnimatedTreeMap.js.example
+++ b/docs/src/docs/TreeMap/examples/AnimatedTreeMap.js.example
@@ -1,5 +1,18 @@
 class AnimatedTreeMapExample extends React.Component {
-  state = {getValue: "size"};
+  constructor(props) {
+    super(props);
+
+    const data = {
+      children: _.range(1, 5).map(n => ({
+        children: _.times(n * n, m => ({
+          size:  (n +1) * (m + 1) + (100 * Math.random()),
+          size2: (n +1) * (m + 1) + (100 * Math.random())
+        }))
+      }))
+    };
+
+    this.state = { getValue: "size", data };
+  }
 
   _animateValue = () => {
     if(this.state.getValue === "size")
@@ -8,23 +21,16 @@ class AnimatedTreeMapExample extends React.Component {
       this.setState({getValue: "size"});
   };
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this._interval = setInterval(this._animateValue, 1000);
-    this._data = {
-      children: _.range(1, 5).map(n => ({
-        children: _.times(n * n, m => ({
-          size:  (n +1) * (m + 1) + (100 * Math.random()),
-          size2: (n +1) * (m + 1) + (100 * Math.random())
-        }))
-      }))
-    };
   }
+
   componentWillUnmount() {
     clearInterval(this._interval);
   }
 
   render() {
-    const {getValue} = this.state;
+    const {getValue, data} = this.state;
 
     const colorScale = d3.scaleLinear()
       .domain([0, 65])
@@ -33,7 +39,7 @@ class AnimatedTreeMapExample extends React.Component {
 
     return <div>
       <TreeMap
-        data={this._data}
+        data={data}
         getValue={getValue}
         getLabel="size"
         nodeStyle={(node) => ({

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -71,18 +71,16 @@ class KernelDensityEstimation extends React.Component {
     return shouldUpdate;
   }
 
-  UNSAFE_componentWillMount() {
-    this.initKDE(this.props);
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const kdeData = KernelDensityEstimation.getKdeData(nextProps);
+    return { kdeData };
   }
-  UNSAFE_componentWillReceiveProps(newProps) {
-    this.initKDE(newProps);
-  }
-  initKDE(props) {
+
+  static getKdeData(props) {
     const { data, bandwidth, sampleCount, xScale, width } = props;
     const kernel = epanechnikovKernel(bandwidth);
     const samples = xScale.ticks(sampleCount || Math.ceil(width / 2));
-
-    this.setState({ kdeData: kernelDensityEstimator(kernel, samples)(data) });
+    return kernelDensityEstimator(kernel, samples)(data);
   }
 
   render() {

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -50,24 +50,25 @@ export default class LineChart extends React.Component {
     curve: curveLinear,
   };
 
+  static getBisectorState(props) {
+    const bisectX = bisector(d => getValue(props.x, d)).left;
+    return { bisectX };
+  }
+
+  static getDerivedStateFromProps(nextProps) {
+    if (nextProps.x) {
+      return LineChart.getBisectorState(nextProps);
+    }
+
+    return null;
+  }
+
+  state = {
+    bisectX: null,
+  };
+
   shouldComponentUpdate(nextProps) {
     return !xyPropsEqual(this.props, nextProps, ['lineStyle', 'lineClassName']);
-  }
-
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillMount() {
-    this.initBisector(this.props);
-  }
-
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.initBisector(nextProps);
-  }
-
-  initBisector(props) {
-    this.setState({
-      bisectX: bisector(d => getValue(props.x, d)).left,
-    });
   }
 
   getHovered = x => {

--- a/tests/jsdom/spec/TreeMap.spec.js
+++ b/tests/jsdom/spec/TreeMap.spec.js
@@ -1,25 +1,24 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import sinon from "sinon";
-import { mount } from "enzyme";
+import React from 'react';
+import _ from 'lodash';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
 
-import { TreeMap } from "../../../src/index.js";
-import TreeMapNode from "../../../src/TreeMapNode.js";
-import TreeMapNodeLabel from "../../../src/TreeMapNodeLabel.js";
+import { TreeMap } from '../../../src/index.js';
+import TreeMapNode from '../../../src/TreeMapNode.js';
+import TreeMapNodeLabel from '../../../src/TreeMapNodeLabel.js';
 
-describe("TreeMap", () => {
+describe('TreeMap', () => {
   const data = {
     children: _.range(1, 5).map(n => ({
       size: n * 5,
-      name: `Name: ${n}`
-    }))
+      name: `Name: ${n}`,
+    })),
   };
 
   const props = {
     data,
-    nodeStyle: { border: "1px solid #333" },
+    nodeStyle: { border: '1px solid #333' },
     getLabel: d => d.name,
     getValue: d => d.size,
     onClickNode: sinon.spy(),
@@ -27,10 +26,10 @@ describe("TreeMap", () => {
     onMouseLeaveNode: sinon.spy(),
     onMouseMoveNode: sinon.spy(),
     width: 400,
-    height: 500
+    height: 500,
   };
 
-  it("passes props correctly to nodes", () => {
+  it('passes props correctly to nodes', () => {
     const chart = mount(<TreeMap {...props} />);
     const nodes = chart.find(TreeMapNode);
 
@@ -39,10 +38,9 @@ describe("TreeMap", () => {
     });
   });
 
-  it("renders correct amount of nodes and labels", () => {
+  it('renders correct amount of nodes and labels', () => {
     const chart = mount(<TreeMap {...props} />);
     const nodes = chart.find(TreeMapNode);
-    const labels = chart.find(TreeMapNodeLabel);
 
     expect(nodes).to.have.lengthOf(5);
 
@@ -51,31 +49,31 @@ describe("TreeMap", () => {
     });
   });
 
-  it("recreates tree when sticky is false, and keeps tree when true", () => {
+  it('recreates tree when sticky is false, and keeps tree when true', () => {
     let chart = mount(<TreeMap {...props} />);
-    let tree = chart.instance()._tree;
+    let tree = chart.instance().state.tree;
 
     chart.setProps({ data });
-    expect(tree).to.not.equal(chart.instance()._tree);
+    expect(tree).to.not.equal(chart.instance().state.tree);
 
     chart = mount(<TreeMap {...props} sticky />);
-    tree = chart.instance()._tree;
+    tree = chart.instance().state.tree;
     chart.setProps({ data });
-    expect(tree).to.eql(chart.instance()._tree);
+    expect(tree).to.eql(chart.instance().state.tree);
   });
 
-  it("triggers event handlers", () => {
+  it('triggers event handlers', () => {
     const chart = mount(<TreeMap {...props} />);
     const nodes = chart.find(TreeMapNode);
 
     expect(props.onMouseMoveNode).not.to.have.been.called;
-    nodes.at(1).simulate("mousemove");
+    nodes.at(1).simulate('mousemove');
     expect(props.onMouseMoveNode).to.have.been.called;
     expect(props.onMouseEnterNode).not.to.have.been.called;
-    nodes.at(1).simulate("mouseenter");
+    nodes.at(1).simulate('mouseenter');
     expect(props.onMouseEnterNode).to.have.been.called;
     expect(props.onMouseLeaveNode).not.to.have.been.called;
-    nodes.at(1).simulate("mouseleave");
+    nodes.at(1).simulate('mouseleave');
     expect(props.onMouseLeaveNode).to.have.been.called;
   });
 });


### PR DESCRIPTION
Fixes #181 

Remove calls prefixed with "UNSAFE_".

I've tested locally with internal apps that cover LineChart, SankeyDiagram, ZoomContainer (with controls). I haven't tested TreeMap or KernelDensityEstimation, so if there's somebody working on app that uses those, it would be great if they could give it a quick test. This shouldn't be required though.

Each commit can be reviewed individually.