### PR TITLE
Add Defs to XYPlot

### DIFF
--- a/docs/src/lessons/XYPlots/XYPlotsLesson.js
+++ b/docs/src/lessons/XYPlots/XYPlotsLesson.js
@@ -81,6 +81,15 @@ export default class XYPlotsLesson extends React.Component {
           label="Multiple Charts in one XYPlot"
           codeText={require('./examples/MultiChart.js.example').default}
         />
+        <p>
+          It's possible to explicitly supply an SVG <code>defs</code> section,
+          for example to define linear gradients.
+        </p>
+        <ExampleSection
+          id="barChartwithDefs"
+          label="Bar Chart With Defs"
+          codeText={require('./examples/BarChartWithDefs.js.example').default}
+        />
       </Lesson>
     );
   }

--- a/docs/src/lessons/XYPlots/examples/BarChartWithDefs.js.example
+++ b/docs/src/lessons/XYPlots/examples/BarChartWithDefs.js.example
@@ -1,0 +1,27 @@
+const BarChartWithDefs = (props) => {
+  const data = [
+    {x: 0, y: 80},
+    {x: 5, y: 60},
+    {x: 10, y: 90},
+    {x: 15, y: 30},
+  ];
+  return <XYPlot width={400} height={300} defs={
+    <linearGradient id="Gradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stopColor="blue" />
+      <stop offset="50%" stopColor="white" />
+      <stop offset="100%" stopColor="red" />
+    </linearGradient>
+  }>
+    <XAxis showGrid={false} title="Days since Zombiepocalypse" />
+    <YAxis title="Zombie Attacks"/>
+    <BarChart
+      barStyle={{fill: "url(#Gradient)"}}
+      data={data}
+      x={d => d.x}
+      y={d => d.y}
+      barThickness={40}
+    />
+  </XYPlot>
+};
+
+ReactDOM.render(<BarChartWithDefs />, mountNode);

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -185,6 +185,12 @@ class XYPlot extends React.Component {
      * Override this prop if you'd like to pass in your own d3 scale.
      */
     yScale: PropTypes.func,
+
+    /**
+     * Optionally define SVG defs for example LinearGradient.
+     */
+    defs: PropTypes.object,
+
     children: PropTypes.any,
   };
 
@@ -198,6 +204,7 @@ class XYPlot extends React.Component {
     xyPlotContainerStyle: {},
     xyPlotStyle: {},
     xyPlotClassName: '',
+    defs: null,
   };
 
   onXYMouseEvent = (callbackKey, event) => {
@@ -216,6 +223,7 @@ class XYPlot extends React.Component {
 
   render() {
     const {
+      defs,
       width,
       height,
       marginTop,
@@ -295,6 +303,7 @@ class XYPlot extends React.Component {
         {...{ width, height, className, style: xyPlotContainerStyle }}
         {...handlers}
       >
+        {defs ? <defs>{defs}</defs> : null}
         <rect className="rct-chart-background" {...{ width, height }} />
         <g
           transform={`translate(${marginLeft + spacingLeft}, ${marginTop +

--- a/src/XYPlot.js
+++ b/src/XYPlot.js
@@ -44,14 +44,14 @@ function getMouseOptions(
   const xValue = !inRange(innerX, 0, chartSize.width)
     ? null
     : xScaleType === 'ordinal'
-      ? invertPointScale(xScale, innerX)
-      : xScale.invert(innerX);
+    ? invertPointScale(xScale, innerX)
+    : xScale.invert(innerX);
 
   const yValue = !inRange(innerY, 0, chartSize.height)
     ? null
     : yScaleType === 'ordinal'
-      ? invertPointScale(yScale, innerY)
-      : yScale.invert(innerY);
+    ? invertPointScale(yScale, innerY)
+    : yScale.invert(innerY);
 
   return {
     event,
@@ -212,7 +212,7 @@ class XYPlot extends React.Component {
   onMouseUp = this.onXYMouseEvent.bind(this, 'onMouseUp');
   onClick = this.onXYMouseEvent.bind(this, 'onClick');
   onMouseEnter = this.onXYMouseEvent.bind(this, 'onMouseEnter');
-  onMouseLeave = this.onXYMouseEvent.bind(this, 'onMouseLeave')
+  onMouseLeave = this.onXYMouseEvent.bind(this, 'onMouseLeave');
 
   render() {
     const {

--- a/tests/jsdom/spec/XYPlot.spec.js
+++ b/tests/jsdom/spec/XYPlot.spec.js
@@ -1,82 +1,82 @@
-import React from "react";
-import sinon from "sinon";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { XYPlot, Bar } from "../../../src/index.js";
+import { XYPlot, Bar } from '../../../src/index.js';
 
-describe("XYPlot", () => {
+describe('XYPlot', () => {
   const commonXYProps = {
     xDomain: [0, 10],
     yDomain: [0, 100],
-    xyPlotClassName: "xy-plot",
-    xyPlotStyle: { fill: "blue" },
-    xyPlotContainerStyle: { opacity: "0.5" }
+    xyPlotClassName: 'xy-plot',
+    xyPlotStyle: { fill: 'blue' },
+    xyPlotContainerStyle: { opacity: '0.5' },
   };
 
-  it("renders SVG with given width, height, style and className (or a default)", () => {
+  it('renders SVG with given width, height, style and className (or a default)', () => {
     const chart = mount(<XYPlot width={600} height={800} {...commonXYProps} />);
-    const svg = chart.find("svg");
-    const plot = chart.find(".rct-plot-background");
+    const svg = chart.find('svg');
+    const plot = chart.find('.rct-plot-background');
 
     // svg className returns SvgAnimatedString, so access baseVal to get string
     // for chai contains to test against
     expect(svg.getDOMNode().className.baseVal).to.contain(
-      commonXYProps.xyPlotClassName
+      commonXYProps.xyPlotClassName,
     );
 
     expect(svg.getDOMNode().style._values).to.eql(
-      commonXYProps.xyPlotContainerStyle
+      commonXYProps.xyPlotContainerStyle,
     );
     expect(plot.getDOMNode().style._values).to.eql(commonXYProps.xyPlotStyle);
 
     const node = svg.instance();
-    expect(node.tagName.toLowerCase()).to.equal("svg");
-    expect(node.getAttribute("width")).to.equal("600");
-    expect(node.getAttribute("height")).to.equal("800");
+    expect(node.tagName.toLowerCase()).to.equal('svg');
+    expect(node.getAttribute('width')).to.equal('600');
+    expect(node.getAttribute('height')).to.equal('800');
 
     const chart2 = mount(<XYPlot {...commonXYProps} />);
-    const node2 = chart2.find("svg").instance();
-    expect(node2.tagName.toLowerCase()).to.equal("svg");
-    expect(parseInt(node2.getAttribute("width"), 10))
-      .to.be.a("number")
+    const node2 = chart2.find('svg').instance();
+    expect(node2.tagName.toLowerCase()).to.equal('svg');
+    expect(parseInt(node2.getAttribute('width'), 10))
+      .to.be.a('number')
       .and.to.be.above(0);
-    expect(parseInt(node2.getAttribute("height"), 10))
-      .to.be.a("number")
+    expect(parseInt(node2.getAttribute('height'), 10))
+      .to.be.a('number')
       .and.to.be.above(0);
   });
 
-  it("renders inner chart area with given margin", () => {
+  it('renders inner chart area with given margin', () => {
     const size = 400;
     const margin = {
       marginTop: 10,
       marginBottom: 20,
       marginLeft: 30,
-      marginRight: 40
+      marginRight: 40,
     };
     const chart = mount(
-      <XYPlot width={size} height={size} {...margin} {...commonXYProps} />
+      <XYPlot width={size} height={size} {...margin} {...commonXYProps} />,
     );
-    const inner = chart.find(".rct-chart-inner").instance();
-    const bg = chart.find(".rct-plot-background").instance();
-    expect(inner.getAttribute("transform").replace(/\s/, "")).to.contain(
-      `translate(${margin.marginLeft},${margin.marginTop})`
+    const inner = chart.find('.rct-chart-inner').instance();
+    const bg = chart.find('.rct-plot-background').instance();
+    expect(inner.getAttribute('transform').replace(/\s/, '')).to.contain(
+      `translate(${margin.marginLeft},${margin.marginTop})`,
     );
-    expect(parseInt(bg.getAttribute("width"), 10)).to.equal(
-      size - (margin.marginLeft + margin.marginRight)
+    expect(parseInt(bg.getAttribute('width'), 10)).to.equal(
+      size - (margin.marginLeft + margin.marginRight),
     );
-    expect(parseInt(bg.getAttribute("height"), 10)).to.equal(
-      size - (margin.marginTop + margin.marginBottom)
+    expect(parseInt(bg.getAttribute('height'), 10)).to.equal(
+      size - (margin.marginTop + margin.marginBottom),
     );
   });
 
-  it("renders children with correct props", () => {
+  it('renders children with correct props', () => {
     const barProps = {
       x: 0,
       y: 0,
       yEnd: 30,
-      style: { fill: "red" },
-      onMouseMove: sinon.spy()
+      style: { fill: 'red' },
+      onMouseMove: sinon.spy(),
     };
     const chart = mount(
       <XYPlot
@@ -86,7 +86,7 @@ describe("XYPlot", () => {
         onMouseMove={sinon.spy()}
       >
         <Bar {...barProps} />
-      </XYPlot>
+      </XYPlot>,
     );
 
     const bar = chart.find(Bar);
@@ -99,12 +99,12 @@ describe("XYPlot", () => {
     // Make sure click handlers passed into bar are correctly triggered
     expect(chart.props().onMouseMove).not.to.have.been.called;
     expect(bar.props().onMouseMove).not.to.have.been.called;
-    bar.simulate("mousemove");
+    bar.simulate('mousemove');
     expect(chart.props().onMouseMove).to.have.been.called;
     expect(bar.props().onMouseMove).to.have.been.called;
   });
 
-  it("triggers event handlers", () => {
+  it('triggers event handlers', () => {
     const mouseHandlers = {
       onMouseMove: sinon.spy(),
       onMouseEnter: sinon.spy(),

--- a/tests/jsdom/spec/XYPlot.spec.js
+++ b/tests/jsdom/spec/XYPlot.spec.js
@@ -140,4 +140,23 @@ describe('XYPlot', () => {
       expect(Object.keys(chartProps[handler].args[0][0])).to.eql(expectedKeys);
     });
   });
+
+  it('renders SVG with defs when provided', () => {
+    const chart = mount(
+      <XYPlot
+        width={600}
+        height={800}
+        defs={
+          <linearGradient id="Gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="blue" />
+            <stop offset="50%" stopColor="white" />
+            <stop offset="100%" stopColor="red" />
+          </linearGradient>
+        }
+        {...commonXYProps}
+      />,
+    );
+    const linearGradient = chart.find('#Gradient');
+    expect(linearGradient).to.have.length(1);
+  });
 });


### PR DESCRIPTION
Adds the ability to pass [SVG defs](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs) to XYPlot. An application of this is the define linear gradients in bar charts.

<img width="1145" alt="Screen Shot 2020-03-25 at 3 11 04 PM" src="https://user-images.githubusercontent.com/87991/77576805-23117b80-6eac-11ea-9938-0abecda91605.png">
