### PR TITLE
Sankey sorting

### DIFF
--- a/src/SankeyDiagram.js
+++ b/src/SankeyDiagram.js
@@ -547,6 +547,10 @@ export default class SankeyDiagram extends React.Component {
      */
     nodeStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /**
+     * Node sort function
+     */
+    nodeSort: PropTypes.func,
+    /**
      * Node `mouseenter` event handler, called when user's mouse enters a node.
      */
     onMouseEnterNode: PropTypes.func,
@@ -580,6 +584,10 @@ export default class SankeyDiagram extends React.Component {
      * or accessor function which returns a class (string).
      */
     linkClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    /**
+     * Link sort function
+     */
+    linkSort: PropTypes.func,
     /**
      * Inline style object to be applied to each link,
      * or accessor function which returns a style object.
@@ -992,6 +1000,8 @@ export default class SankeyDiagram extends React.Component {
       .nodeId(props.nodeId)
       .nodeWidth(props.nodeWidth)
       .nodePadding(props.nodePadding)
+      .nodeSort(props.nodeSort)
+      .linkSort(props.linkSort)
       .nodeAlign(
         nodeAlignmentsByName[props.nodeAlignment] ||
           nodeAlignmentsByName.justify,

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -123,9 +123,14 @@ export default class ZoomContainer extends React.Component {
 
   state = { lastZoomTransform: null, selection: null };
 
+  constructor(props) {
+    super(props);
+    this.svgRef = React.createRef();
+  }
+
   componentDidMount() {
     const initialZoomTransform = zoomTransformFromProps(this.props);
-    const selection = d3.select(this.refs.svg);
+    const selection = d3.select(this.svgRef.current);
 
     this.zoom = d3.zoom();
     selection.call(this.zoom);
@@ -225,12 +230,17 @@ export default class ZoomContainer extends React.Component {
   }
 
   render() {
-    const zoomTransform = this.refs.svg
-      ? d3.zoomTransform(this.refs.svg)
-      : null;
+    const zoomTransform =
+      this.svgRef && this.svgRef.current
+        ? d3.zoomTransform(this.svgRef.current)
+        : null;
 
     return (
-      <svg ref="svg" width={this.props.width} height={this.props.height}>
+      <svg
+        ref={this.svgRef}
+        width={this.props.width}
+        height={this.props.height}
+      >
         <g
           width={this.props.width}
           height={this.props.height}


### PR DESCRIPTION
 * Remove deprecate refs definition using strings. For some reason this was breaking local development using `npm link` and it's good to fix.
 * Add `nodeSort` and `linkSort` hooks to SankeyDiagram component.