### PR TITLE
Small YAxisLabels formatting example fix

### DIFF
--- a/docs/src/docs/YAxisLabels/examples/YAxisLabels.js.example
+++ b/docs/src/docs/YAxisLabels/examples/YAxisLabels.js.example
@@ -15,7 +15,7 @@ const YAxisLabelsExample = (props) => {
           position="right"
           tickCount={5}
           labelStyle={(label) => {
-            const is20 = label.text === "20.00"
+            const is20 = Math.abs(label.value) === 20;
             return {
               fill: is20 ? "green" : "black",
               fontWeight: is20 ? 900 : 400


### PR DESCRIPTION
The current example did not demonstrate label color/weight change, since the final label (`label.text`) never was `20.00`.