### PR TITLE
Upgrade D3 6.3.1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "no-nested-ternary": "off",
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/no-noninteractive-element-interactions": "off"
+    "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "no-restricted-imports": ["error", "d3"]
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,9 +1,9 @@
 <html>
-<head>
+  <head>
     <title>Redirect</title>
-    <META http-equiv="refresh" content="0;URL=build">
-</head>
-<body bgcolor="#ffffff">
-Redirecting to docs...
-</body>
+    <meta http-equiv="refresh" content="0;URL=build" />
+  </head>
+  <body bgcolor="#ffffff">
+    Redirecting to docs...
+  </body>
 </html>

--- a/docs/src/ExampleSection.js
+++ b/docs/src/ExampleSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import * as d3 from 'd3';
+import * as d3 from 'd3'; // eslint-disable-line no-restricted-imports
 import Playground from 'component-playground';
 
 // import *all* reactochart components/utils - usually you'd import one at a time

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -1,6 +1,6 @@
-import "../styles/main.less";
-import React from "react";
-import ReactDOM from "react-dom";
-import { App } from "./App";
+import '../styles/main.less';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from './App';
 
-ReactDOM.render(<App />, document.getElementById("container"));
+ReactDOM.render(<App />, document.getElementById('container'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.0.tgz",
       "integrity": "sha512-FGgV2XyPoVtYDvbFXlukEWt13Afka4mBRQ2CoTsHxpgVGO6XfgtT6eI+WyjQRGGTL90IDkIVmme8riFCLZ8lUw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.10.0",
@@ -75,6 +76,7 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
@@ -83,6 +85,7 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
           "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
@@ -93,6 +96,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -101,6 +105,7 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -108,12 +113,14 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -121,6 +128,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.0.tgz",
       "integrity": "sha512-ThoWCJHlgukbtCP79nAK4oLqZt5fVo70AHUni/y8Jotyg5rtJiG2FVl+iJjRNKIyl4hppqztLyAoEWcCvqyOFQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.0",
         "jsesc": "^2.5.1",
@@ -242,6 +250,7 @@
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
       "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -252,6 +261,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
       "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -269,6 +279,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.0.tgz",
       "integrity": "sha512-xKLTpbMkJcvwEsDaTfs9h0IlfUiBLPFfybxaPpPPsQDsZTRg+UKh+86oK7sctHF3OUiRQkb10oS9MXSqgyV6/g==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.0"
       }
@@ -305,6 +316,7 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
       "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-replace-supers": "^7.8.6",
@@ -319,6 +331,7 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
           "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.8.3"
           }
@@ -329,6 +342,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.0.tgz",
       "integrity": "sha512-HgMd8QKA8wMJs5uK/DYKdyzJAEuGt1zyDp9wLMlMR6LitTQTHPUE+msC82ZsEDwq+U3/yHcIXIngRm9MS4IcIg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.0"
       }
@@ -336,7 +350,8 @@
     "@babel/helper-plugin-utils": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+      "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.8.3",
@@ -364,6 +379,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.0.tgz",
       "integrity": "sha512-erl4iVeiANf14JszXP7b69bSrz3e3+qW09pVvEmTWwzRQEOoyb1WFlYCA8d/VjVZGYW8+nGpLh7swf9CifH5wg==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.10.0",
         "@babel/helper-optimise-call-expression": "^7.10.0",
@@ -375,6 +391,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
       "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3"
@@ -384,6 +401,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -391,7 +409,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
@@ -409,6 +428,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.0.tgz",
       "integrity": "sha512-lQtFJoDZAGf/t2PgR6Z59Q2MwjvOGGsxZ0BAlsrgyDhKuMbe63EfbQmVmcLfyTBj8J4UtiadQimcotvYVg/kVQ==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.10.0",
         "@babel/traverse": "^7.10.0",
@@ -428,7 +448,8 @@
     "@babel/parser": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.0.tgz",
-      "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ=="
+      "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==",
+      "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.8.3",
@@ -618,6 +639,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -1220,6 +1242,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.0.tgz",
       "integrity": "sha512-aMLEQn5tcG49LEWrsEwxiRTdaJmvLem3+JMCMSeCy2TILau0IDVyWdm/18ACx7XOCady64FLt6KkHy28tkDQHQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.10.0",
@@ -1230,6 +1253,7 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
@@ -1238,6 +1262,7 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
           "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
@@ -1250,6 +1275,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.0.tgz",
       "integrity": "sha512-NZsFleMaLF1zX3NxbtXI/JCs2RPOdpGru6UBdGsfhdsDsP+kFF+h2QQJnMJglxk0kc69YmMFs4A44OJY0tKo5g==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.10.0",
@@ -1266,6 +1292,7 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
@@ -1274,6 +1301,7 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
           "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
@@ -1284,6 +1312,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1291,7 +1320,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -1299,6 +1329,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.0.tgz",
       "integrity": "sha512-t41W8yWFyQFPOAAvPvjyRhejcLGnJTA3iRpFcDbEKwVJ3UnHQePFzLk8GagTsucJlImyNwrGikGsYURrWbQG8w==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
         "lodash": "^4.17.13",
@@ -1309,6 +1340,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
       "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+      "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
@@ -1317,7 +1349,8 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -1556,6 +1589,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+      "dev": true,
       "requires": {
         "@jest/source-map": "^24.9.0",
         "chalk": "^2.0.1",
@@ -1566,6 +1600,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
       "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+      "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
         "@jest/reporters": "^24.9.0",
@@ -1600,17 +1635,20 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -1621,6 +1659,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+      "dev": true,
       "requires": {
         "@jest/fake-timers": "^24.9.0",
         "@jest/transform": "^24.9.0",
@@ -1632,6 +1671,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "jest-message-util": "^24.9.0",
@@ -1642,6 +1682,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
       "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+      "dev": true,
       "requires": {
         "@jest/environment": "^24.9.0",
         "@jest/test-result": "^24.9.0",
@@ -1669,7 +1710,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -1677,6 +1719,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0",
         "graceful-fs": "^4.1.15",
@@ -1686,12 +1729,14 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -1699,6 +1744,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+      "dev": true,
       "requires": {
         "@jest/console": "^24.9.0",
         "@jest/types": "^24.9.0",
@@ -1709,6 +1755,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
       "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+      "dev": true,
       "requires": {
         "@jest/test-result": "^24.9.0",
         "jest-haste-map": "^24.9.0",
@@ -1720,6 +1767,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
         "@jest/types": "^24.9.0",
@@ -1742,12 +1790,14 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -1755,6 +1805,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
@@ -2774,6 +2825,7 @@
       "version": "7.1.8",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
       "integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -2786,6 +2838,7 @@
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
       "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -2794,6 +2847,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -2803,6 +2857,7 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.12.tgz",
       "integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
       }
@@ -2852,12 +2907,14 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -2866,6 +2923,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -2953,7 +3011,8 @@
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
     },
     "@types/tapable": {
       "version": "1.0.4",
@@ -3029,6 +3088,7 @@
       "version": "13.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
       "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -3036,7 +3096,8 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -3483,7 +3544,8 @@
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -3522,6 +3584,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+      "dev": true,
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -3530,7 +3593,8 @@
         "acorn": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
         }
       }
     },
@@ -3543,7 +3607,8 @@
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+      "dev": true
     },
     "agent-base": {
       "version": "5.1.1",
@@ -3631,7 +3696,8 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -3669,6 +3735,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -3678,6 +3745,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -3723,7 +3791,8 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "array-filter": {
       "version": "1.0.0",
@@ -3939,6 +4008,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -4036,7 +4106,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -4064,7 +4135,8 @@
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -4084,12 +4156,14 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -4105,12 +4179,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "axe-core": {
       "version": "3.5.5",
@@ -4253,6 +4329,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+      "dev": true,
       "requires": {
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
@@ -4379,6 +4456,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "find-up": "^3.0.0",
@@ -4390,6 +4468,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+      "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
       }
@@ -4561,6 +4640,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+      "dev": true,
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
@@ -4659,6 +4739,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -4686,6 +4767,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -4815,12 +4897,14 @@
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -4828,7 +4912,8 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
         }
       }
     },
@@ -4969,6 +5054,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
       }
@@ -4999,7 +5085,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -5131,7 +5218,8 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
@@ -5146,7 +5234,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -5177,6 +5266,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+      "dev": true,
       "requires": {
         "rsvp": "^4.8.4"
       }
@@ -5194,7 +5284,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "ccount": {
       "version": "1.0.4",
@@ -5361,7 +5452,8 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -5519,6 +5611,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -5528,12 +5621,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "execa": {
           "version": "1.0.0",
@@ -5639,6 +5734,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -5649,6 +5745,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -5669,7 +5766,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -5721,6 +5819,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -6212,6 +6311,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -6720,117 +6820,138 @@
       }
     },
     "d3": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-5.16.0.tgz",
-      "integrity": "sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.3.1.tgz",
+      "integrity": "sha512-rbaoA67o2N4lO1TCuvrTGQdowNb3zT0z2ygg6TLmJZAd7TRPg+lhbfDOVwQUAgdbRD+73kg2FrEQ9HLiap5H2w==",
       "requires": {
-        "d3-array": "1",
-        "d3-axis": "1",
-        "d3-brush": "1",
-        "d3-chord": "1",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-contour": "1",
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-dsv": "1",
-        "d3-ease": "1",
-        "d3-fetch": "1",
-        "d3-force": "1",
-        "d3-format": "1",
-        "d3-geo": "1",
-        "d3-hierarchy": "1",
-        "d3-interpolate": "1",
-        "d3-path": "1",
-        "d3-polygon": "1",
-        "d3-quadtree": "1",
-        "d3-random": "1",
-        "d3-scale": "2",
-        "d3-scale-chromatic": "1",
-        "d3-selection": "1",
-        "d3-shape": "1",
-        "d3-time": "1",
-        "d3-time-format": "2",
-        "d3-timer": "1",
-        "d3-transition": "1",
-        "d3-voronoi": "1",
-        "d3-zoom": "1"
-      }
-    },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "d3-axis": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-      "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
-    },
-    "d3-brush": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.5.tgz",
-      "integrity": "sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==",
-      "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "d3-chord": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz",
-      "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
-      "requires": {
-        "d3-array": "1",
-        "d3-path": "1"
-      }
-    },
-    "d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-    },
-    "d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-    },
-    "d3-contour": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
-      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
-      "requires": {
-        "d3-array": "^1.1.1"
-      }
-    },
-    "d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
-    },
-    "d3-drag": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
-      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
-      "requires": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
+        "d3-array": "2",
+        "d3-axis": "2",
+        "d3-brush": "2",
+        "d3-chord": "2",
+        "d3-color": "2",
+        "d3-contour": "2",
+        "d3-delaunay": "5",
+        "d3-dispatch": "2",
+        "d3-drag": "2",
+        "d3-dsv": "2",
+        "d3-ease": "2",
+        "d3-fetch": "2",
+        "d3-force": "2",
+        "d3-format": "2",
+        "d3-geo": "2",
+        "d3-hierarchy": "2",
+        "d3-interpolate": "2",
+        "d3-path": "2",
+        "d3-polygon": "2",
+        "d3-quadtree": "2",
+        "d3-random": "2",
+        "d3-scale": "3",
+        "d3-scale-chromatic": "2",
+        "d3-selection": "2",
+        "d3-shape": "2",
+        "d3-time": "2",
+        "d3-time-format": "3",
+        "d3-timer": "2",
+        "d3-transition": "2",
+        "d3-zoom": "2"
       },
       "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        "d3-array": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
+          "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+        },
+        "d3-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+          "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+        },
+        "d3-shape": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.0.0.tgz",
+          "integrity": "sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==",
+          "requires": {
+            "d3-path": "1 - 2"
+          }
         }
       }
     },
+    "d3-array": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
+      "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+    },
+    "d3-axis": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.0.0.tgz",
+      "integrity": "sha512-9nzB0uePtb+u9+dWir+HTuEAKJOEUYJoEwbJPsZ1B4K3iZUgzJcSENQ05Nj7S4CIfbZZ8/jQGoUzGKFznBhiiQ=="
+    },
+    "d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "d3-chord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+      "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-contour": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+      "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "requires": {
+        "d3-array": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
+          "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+        }
+      }
+    },
+    "d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "requires": {
+        "delaunator": "4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
     "d3-dsv": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
       "requires": {
         "commander": "2",
         "iconv-lite": "0.4",
@@ -6838,53 +6959,59 @@
       }
     },
     "d3-ease": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.6.tgz",
-      "integrity": "sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
     },
     "d3-fetch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.2.0.tgz",
-      "integrity": "sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+      "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
       "requires": {
-        "d3-dsv": "1"
+        "d3-dsv": "1 - 2"
       }
     },
     "d3-force": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
       "requires": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
       }
     },
     "d3-format": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
-      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "d3-geo": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
-      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
+      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
       "requires": {
-        "d3-array": "1"
+        "d3-array": ">=2.5"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
+          "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+        }
       }
     },
     "d3-hierarchy": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
     },
     "d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
       "requires": {
-        "d3-color": "1"
+        "d3-color": "1 - 2"
       }
     },
     "d3-path": {
@@ -6893,19 +7020,19 @@
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "d3-polygon": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.6.tgz",
-      "integrity": "sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
     },
     "d3-quadtree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
     },
     "d3-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.2.tgz",
-      "integrity": "sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
     },
     "d3-sankey": {
       "version": "0.12.3",
@@ -6917,31 +7044,37 @@
       }
     },
     "d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
       "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "1 - 2",
+        "d3-time-format": "2 - 3"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
+          "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+        }
       }
     },
     "d3-scale-chromatic": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
-      "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "requires": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
+        "d3-color": "1 - 2",
+        "d3-interpolate": "1 - 2"
       }
     },
     "d3-selection": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "d3-shape": {
       "version": "1.3.7",
@@ -6959,186 +7092,45 @@
       }
     },
     "d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
+      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
     },
     "d3-time-format": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
       "requires": {
-        "d3-time": "1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
+        "d3-time": "1 - 2"
       }
     },
     "d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
     },
     "d3-transition": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
-      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
       "requires": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
       }
     },
-    "d3-voronoi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
-    },
     "d3-zoom": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
-      "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
       "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-        },
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-          "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "import-local": "^2.0.0",
-            "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
-            "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
-          }
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
       }
     },
     "dargs": {
@@ -7151,6 +7143,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       },
@@ -7191,6 +7184,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
       "requires": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
@@ -7273,7 +7267,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -7289,6 +7284,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7400,10 +7396,16 @@
         }
       }
     },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -7457,7 +7459,8 @@
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
     },
     "detect-node": {
       "version": "2.0.4",
@@ -7474,7 +7477,8 @@
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
+      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -7601,6 +7605,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
@@ -7670,6 +7675,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -8031,6 +8037,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -8043,6 +8050,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -8052,12 +8060,14 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-symbol": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -8079,6 +8089,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -8095,7 +8106,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         },
         "mime": {
           "version": "1.6.0",
@@ -8106,6 +8118,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }
@@ -8890,7 +8903,8 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -8937,12 +8951,14 @@
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
-      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A=="
+      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+      "dev": true
     },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -8957,6 +8973,7 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -8970,7 +8987,8 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -9017,6 +9035,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
       "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "ansi-styles": "^3.2.0",
@@ -9087,7 +9106,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -9192,12 +9212,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -9268,12 +9290,14 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.8.0",
@@ -9296,6 +9320,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
       "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "dev": true,
       "requires": {
         "bser": "2.1.1"
       }
@@ -9351,6 +9376,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "filelist": {
@@ -9568,12 +9594,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -9656,6 +9684,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -9665,7 +9694,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.2",
@@ -9780,12 +9810,14 @@
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -9809,6 +9841,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -9822,6 +9855,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -9980,6 +10014,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10046,7 +10081,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globby": {
       "version": "6.1.0",
@@ -10083,7 +10119,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -10131,12 +10168,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "dev": true,
       "requires": {
         "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
@@ -10146,6 +10185,7 @@
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
           "requires": {
             "co": "^4.6.0",
             "fast-deep-equal": "^1.0.0",
@@ -10165,6 +10205,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10381,6 +10422,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -10394,7 +10436,8 @@
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "html-minifier": {
       "version": "3.5.21",
@@ -10561,6 +10604,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -10837,6 +10881,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "dev": true,
       "requires": {
         "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
@@ -10845,7 +10890,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -11140,12 +11186,14 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
       }
@@ -11171,7 +11219,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -11221,12 +11270,14 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -11327,6 +11378,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -11371,7 +11423,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -11399,7 +11452,8 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -11434,7 +11488,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "issue-parser": {
       "version": "5.0.0",
@@ -11452,12 +11507,14 @@
     "istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
       "requires": {
         "@babel/generator": "^7.4.0",
         "@babel/parser": "^7.4.3",
@@ -11471,7 +11528,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -11479,6 +11537,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^2.0.5",
         "make-dir": "^2.1.0",
@@ -11489,6 +11548,7 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -11499,6 +11559,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^2.0.5",
@@ -11511,6 +11572,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -11518,12 +11580,14 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -11531,7 +11595,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -11539,6 +11604,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
       "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+      "dev": true,
       "requires": {
         "html-escaper": "^2.0.0"
       }
@@ -11606,6 +11672,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "execa": "^1.0.0",
@@ -11616,6 +11683,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
       "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
         "@jest/test-sequencer": "^24.9.0",
@@ -11640,6 +11708,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "diff-sequences": "^24.9.0",
@@ -11651,6 +11720,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+      "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
       }
@@ -11659,6 +11729,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "chalk": "^2.0.1",
@@ -11671,6 +11742,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
       "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+      "dev": true,
       "requires": {
         "@jest/environment": "^24.9.0",
         "@jest/fake-timers": "^24.9.0",
@@ -11683,17 +11755,20 @@
         "acorn": {
           "version": "5.7.4",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
         },
         "cssom": {
           "version": "0.3.8",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
         },
         "cssstyle": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
           "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+          "dev": true,
           "requires": {
             "cssom": "0.3.x"
           }
@@ -11702,6 +11777,7 @@
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
           "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+          "dev": true,
           "requires": {
             "abab": "^2.0.0",
             "acorn": "^5.5.3",
@@ -11734,12 +11810,14 @@
         "parse5": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+          "dev": true
         },
         "whatwg-url": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
           "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -11750,6 +11828,7 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -11760,6 +11839,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+      "dev": true,
       "requires": {
         "@jest/environment": "^24.9.0",
         "@jest/fake-timers": "^24.9.0",
@@ -11771,12 +11851,14 @@
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+      "dev": true
     },
     "jest-haste-map": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
@@ -11795,7 +11877,8 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         }
       }
     },
@@ -11803,6 +11886,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
       "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+      "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
         "@jest/environment": "^24.9.0",
@@ -11855,6 +11939,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+      "dev": true,
       "requires": {
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
@@ -11864,6 +11949,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-diff": "^24.9.0",
@@ -11875,6 +11961,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@jest/test-result": "^24.9.0",
@@ -11890,6 +11977,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0"
       }
@@ -11897,17 +11985,20 @@
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
+      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "dev": true
     },
     "jest-regex-util": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-      "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA=="
+      "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+      "dev": true
     },
     "jest-resolve": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
       "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "browser-resolve": "^1.11.3",
@@ -11920,6 +12011,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "jest-regex-util": "^24.3.0",
@@ -11930,6 +12022,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
       "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+      "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
         "@jest/environment": "^24.9.0",
@@ -11955,7 +12048,8 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         }
       }
     },
@@ -11963,6 +12057,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
       "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+      "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
         "@jest/environment": "^24.9.0",
@@ -11992,19 +12087,22 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         }
       }
     },
     "jest-serializer": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-      "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
+      "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+      "dev": true
     },
     "jest-snapshot": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
         "@jest/types": "^24.9.0",
@@ -12024,7 +12122,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -12032,6 +12131,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+      "dev": true,
       "requires": {
         "@jest/console": "^24.9.0",
         "@jest/fake-timers": "^24.9.0",
@@ -12050,12 +12150,14 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -12063,6 +12165,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "camelcase": "^5.3.1",
@@ -12076,6 +12179,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+      "dev": true,
       "requires": {
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
@@ -12090,6 +12194,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "dev": true,
       "requires": {
         "merge-stream": "^2.0.0",
         "supports-color": "^6.1.0"
@@ -12099,6 +12204,7 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -12124,6 +12230,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -12188,7 +12295,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
@@ -12204,12 +12312,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -12220,7 +12330,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.3",
@@ -12251,6 +12362,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -12278,7 +12390,8 @@
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
     },
     "language-subtag-registry": {
       "version": "0.3.20",
@@ -12307,7 +12420,8 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "less": {
       "version": "3.11.1",
@@ -12419,7 +12533,8 @@
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levenary": {
       "version": "1.1.1",
@@ -12434,6 +12549,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -12628,6 +12744,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -12639,6 +12756,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -12647,7 +12765,8 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -12764,7 +12883,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -12917,6 +13037,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -12925,7 +13046,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -12939,6 +13061,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
       "requires": {
         "tmpl": "1.0.x"
       }
@@ -13282,6 +13405,7 @@
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -13326,12 +13450,14 @@
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.35.0"
       }
@@ -13381,7 +13507,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -13455,6 +13582,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -13756,6 +13884,7 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -13779,7 +13908,8 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "nearley": {
       "version": "2.19.3",
@@ -13926,7 +14056,8 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -13962,12 +14093,14 @@
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
     },
     "node-notifier": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
       "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "dev": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^1.1.0",
@@ -17602,12 +17735,14 @@
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -17729,7 +17864,8 @@
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -17914,6 +18050,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -18091,6 +18228,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -18103,7 +18241,8 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
         }
       }
     },
@@ -18159,6 +18298,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "dev": true,
       "requires": {
         "p-reduce": "^1.0.0"
       }
@@ -18231,7 +18371,8 @@
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
     },
     "p-retry": {
       "version": "4.2.0",
@@ -18438,7 +18579,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.1.1",
@@ -18449,7 +18591,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -18470,6 +18613,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
       "requires": {
         "node-modules-regexp": "^1.0.0"
       }
@@ -18499,6 +18643,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
       "requires": {
         "find-up": "^3.0.0"
       }
@@ -18541,7 +18686,8 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.26",
@@ -18665,7 +18811,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prettier": {
       "version": "1.18.2",
@@ -18687,6 +18834,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.9.0",
         "ansi-regex": "^4.0.0",
@@ -18697,7 +18845,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         }
       }
     },
@@ -18743,6 +18892,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
       "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "dev": true,
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
@@ -18809,7 +18959,8 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -18868,7 +19019,8 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -18878,7 +19030,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -19404,6 +19557,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
@@ -19439,6 +19593,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
       }
@@ -19741,7 +19896,8 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "renderkid": {
       "version": "2.0.2",
@@ -19832,6 +19988,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -19859,6 +20016,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -19867,6 +20025,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
@@ -19876,12 +20035,14 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "require-package-name": {
       "version": "2.0.1",
@@ -19932,6 +20093,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -19940,6 +20102,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
       },
@@ -19947,7 +20110,8 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
         }
       }
     },
@@ -20275,6 +20439,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -20302,7 +20467,8 @@
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -20378,6 +20544,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "dev": true,
       "requires": {
         "@cnakazawa/watch": "^1.0.3",
         "anymatch": "^2.0.0",
@@ -20393,14 +20560,16 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "saxes": {
       "version": "3.1.11",
@@ -20954,7 +21123,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -21026,7 +21196,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
     },
     "side-channel": {
       "version": "1.0.2",
@@ -21216,12 +21387,14 @@
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
     },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -21608,6 +21781,7 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -21616,7 +21790,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -21783,6 +21958,7 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -21807,7 +21983,8 @@
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
     },
     "staged-git-files": {
       "version": "1.1.2",
@@ -21849,7 +22026,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -21910,6 +22088,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
       "requires": {
         "astral-regex": "^1.0.0",
         "strip-ansi": "^4.0.0"
@@ -21918,12 +22097,14 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -22615,7 +22796,8 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "synchronous-promise": {
       "version": "2.0.13",
@@ -22774,6 +22956,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3",
         "minimatch": "^3.0.4",
@@ -22785,6 +22968,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "dev": true,
           "requires": {
             "find-up": "^3.0.0",
             "read-pkg": "^3.0.0"
@@ -22806,7 +22990,8 @@
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -22861,7 +23046,8 @@
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -22872,7 +23058,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -22928,6 +23115,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -22937,6 +23125,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -22944,7 +23133,8 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
         }
       }
     },
@@ -23064,6 +23254,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -23072,12 +23263,14 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -23480,6 +23673,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -23500,7 +23694,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -23533,6 +23728,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -23591,6 +23787,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
       }
@@ -23610,6 +23807,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
       "requires": {
         "makeerror": "1.0.x"
       }
@@ -23774,7 +23972,8 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "webpack": {
       "version": "4.43.0",
@@ -24241,6 +24440,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
       },
@@ -24249,6 +24449,7 @@
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -24264,12 +24465,14 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
       "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -24287,7 +24490,8 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -24338,6 +24542,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -24347,17 +24552,20 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -24368,6 +24576,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -24392,6 +24601,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -24416,7 +24626,8 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -24441,7 +24652,8 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -24479,6 +24691,7 @@
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -24495,17 +24708,20 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -24516,6 +24732,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -24524,6 +24741,7 @@
           "version": "13.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test-watch": "cross-env NODE_PATH=$NODE_PATH:$PWD/src BABEL_ENV=production mocha --watch --require @babel/register tests/jsdom/setup.js --recursive tests/jsdom/spec"
   },
   "dependencies": {
-    "d3": "^5.16.0",
+    "d3": "^6.3.1",
     "d3-sankey": "^0.12.3",
     "invariant": "^2.2.0",
     "lodash": "^4.17.15",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,9 +1,9 @@
-const fs = require("fs");
-const sh = require("shelljs");
+const fs = require('fs');
+const sh = require('shelljs');
 
-const { fileExists, dirExists } = require("./utils");
+const { fileExists, dirExists } = require('./utils');
 
-const srcContents = sh.ls("src");
+const srcContents = sh.ls('src');
 
 // We don't want to commit built files, so it is useful to have a `clean` script which deletes them if they exist.
 // However, Reactochart is built in the root directory
@@ -19,7 +19,7 @@ srcContents.forEach(fileOrDir => {
     sh.rm(`./${fileOrDir}`);
   } else if (dirExists(`src/${fileOrDir}`) && dirExists(fileOrDir)) {
     console.log(`deleting directory ./${fileOrDir}`);
-    sh.rm("-rf", `./${fileOrDir}`);
+    sh.rm('-rf', `./${fileOrDir}`);
   }
   // check for source maps too
   if (fileExists(`./${fileOrDir}.map`)) {
@@ -29,6 +29,6 @@ srcContents.forEach(fileOrDir => {
 });
 
 // Clean compiled css file
-if (fileExists("./styles.css")) {
-  sh.rm("./styles.css");
+if (fileExists('./styles.css')) {
+  sh.rm('./styles.css');
 }

--- a/scripts/makeDocs.js
+++ b/scripts/makeDocs.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
-const sh = require("shelljs");
-const _ = require("lodash");
+const fs = require('fs');
+const sh = require('shelljs');
+const _ = require('lodash');
 
 const {
   isUpperCase,
@@ -8,10 +8,10 @@ const {
   dirExists,
   ensureDir,
   fileNameFromPath,
-  stripFileExtension
-} = require("./utils");
+  stripFileExtension,
+} = require('./utils');
 
-const EXCLUDED_DOCGEN_FILES = ["TreeMapNode.js", "TreeMapNodeLabel.js"];
+const EXCLUDED_DOCGEN_FILES = ['TreeMapNode.js', 'TreeMapNodeLabel.js'];
 
 const docsDirPath = `${__dirname}/../docs/src/docs`;
 const docsPageTemplatePath = `${__dirname}/../docs/src/templates/ComponentDocsPage.js.template`;
@@ -23,7 +23,7 @@ const jsFilePaths = sh.ls(`${__dirname}/../src/*.js`);
 const componentPaths = jsFilePaths.filter(
   path =>
     !EXCLUDED_DOCGEN_FILES.includes(fileNameFromPath(path)) &&
-    isUpperCase(fileNameFromPath(path)[0])
+    isUpperCase(fileNameFromPath(path)[0]),
 );
 
 ensureDir(docsDirPath);
@@ -34,9 +34,9 @@ componentPaths.forEach(path => {
 
   // use react-docgen to autogenerate prop docs json file from component src files
   ensureDir(componentDocsPath);
-  console.log("Generating prop docs for", componentName);
+  console.log('Generating prop docs for', componentName);
   sh.exec(
-    `react-docgen ${path} --pretty -o ${componentDocsPath}/propDocs.json`
+    `react-docgen ${path} --pretty -o ${componentDocsPath}/propDocs.json`,
   );
 
   const docsPagePath = `${componentDocsPath}/${componentName}Docs.js`;
@@ -49,7 +49,7 @@ componentPaths.forEach(path => {
     const docsPageStub = docsTemplate({ componentName });
     fs.writeFile(docsPagePath, docsPageStub, err => {
       if (err) throw err;
-      console.log("wrote to", docsPagePath);
+      console.log('wrote to', docsPagePath);
     });
 
     // use template to generate stub example file, to be used for live preview (using component-playground)
@@ -58,7 +58,7 @@ componentPaths.forEach(path => {
     ensureDir(examplesDirPath);
     fs.writeFile(examplePath, exampleStub, err => {
       if (err) throw err;
-      console.log("wrote to", examplePath);
+      console.log('wrote to', examplePath);
     });
   }
 });
@@ -69,7 +69,7 @@ const componentDocExports = componentPaths.map(componentPath => {
   const componentName = stripFileExtension(fileName);
   return `export {default as ${componentName}Docs} from './${componentName}/${componentName}Docs';\n`;
 });
-fs.writeFile(`${docsDirPath}/index.js`, componentDocExports.join(""), err => {
+fs.writeFile(`${docsDirPath}/index.js`, componentDocExports.join(''), err => {
   if (err) throw err;
-  console.log("wrote exports");
+  console.log('wrote exports');
 });

--- a/scripts/makeLesson.js
+++ b/scripts/makeLesson.js
@@ -2,34 +2,44 @@ const fs = require('fs');
 const sh = require('shelljs');
 const _ = require('lodash');
 
-const {isUpperCase, fileExists, dirExists, ensureDir, fileNameFromPath, stripFileExtension} = require('./utils');
+const {
+  isUpperCase,
+  fileExists,
+  dirExists,
+  ensureDir,
+  fileNameFromPath,
+  stripFileExtension,
+} = require('./utils');
 
 const lessonsDirPath = `${__dirname}/../docs/src/lessons`;
 const lessonTemplatePath = `${__dirname}/../docs/src/templates/Lesson.js.template`;
 const exampleTemplatePath = `${__dirname}/../docs/src/templates/ComponentExample.js.template`;
 
 if (process.argv.length <= 2) {
-  console.log("Usage: " + __filename + " LESSON_NAME");
+  console.log(`Usage: ${__filename} LESSON_NAME`);
   process.exit(-1);
 }
 
 const lessonName = process.argv[2];
 console.log(lessonName);
 
-const componentName = lessonName.split(" ").map(_.capitalize).join('');
+const componentName = lessonName
+  .split(' ')
+  .map(_.capitalize)
+  .join('');
 console.log('componentName', componentName);
 const lessonDirPath = `${lessonsDirPath}/${componentName}`;
 const lessonComponentPath = `${lessonDirPath}/${componentName}Lesson.js`;
 
 ensureDir(lessonsDirPath);
 ensureDir(lessonDirPath);
-if(!fileExists(lessonComponentPath)) {
+if (!fileExists(lessonComponentPath)) {
   // use template file to generate a stub example page for this component
   const lessonTemplate = _.template(sh.cat(lessonTemplatePath).toString());
-  const lessonStub = lessonTemplate({name: lessonName, componentName});
-  fs.writeFile(lessonComponentPath, lessonStub, (err) => {
-    if(err) throw err;
-    console.log("created stub lesson component:", lessonComponentPath);
+  const lessonStub = lessonTemplate({ name: lessonName, componentName });
+  fs.writeFile(lessonComponentPath, lessonStub, err => {
+    if (err) throw err;
+    console.log('created stub lesson component:', lessonComponentPath);
   });
 
   const examplesDirPath = `${lessonDirPath}/examples`;
@@ -37,10 +47,10 @@ if(!fileExists(lessonComponentPath)) {
 
   // use template to generate stub example file, to be used for live preview (using component-playground)
   const exampleTemplate = _.template(sh.cat(exampleTemplatePath).toString());
-  const exampleStub = exampleTemplate({componentName});
+  const exampleStub = exampleTemplate({ componentName });
   ensureDir(examplesDirPath);
-  fs.writeFile(examplePath, exampleStub, (err) => {
-    if(err) throw err;
-    console.log("created stub example:", examplePath);
+  fs.writeFile(examplePath, exampleStub, err => {
+    if (err) throw err;
+    console.log('created stub example:', examplePath);
   });
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,7 +12,7 @@ function dirExists(path) {
   return sh.test('-d', path);
 }
 function ensureDir(path) {
-  if(!dirExists(path)) sh.mkdir('-p', path);
+  if (!dirExists(path)) sh.mkdir('-p', path);
 }
 function fileNameFromPath(path) {
   return _.last(path.split('/'));
@@ -22,5 +22,10 @@ function stripFileExtension(fileName) {
 }
 
 module.exports = {
-  isUpperCase, fileExists, dirExists, ensureDir, fileNameFromPath, stripFileExtension
+  isUpperCase,
+  fileExists,
+  dirExists,
+  ensureDir,
+  fileNameFromPath,
+  stripFileExtension,
 };

--- a/src/AreaChart.js
+++ b/src/AreaChart.js
@@ -1,4 +1,4 @@
-import { area } from 'd3';
+import { area } from 'd3-shape';
 import isUndefined from 'lodash/isUndefined';
 import uniqueId from 'lodash/uniqueId';
 import PropTypes from 'prop-types';

--- a/src/AreaHeatmap.js
+++ b/src/AreaHeatmap.js
@@ -1,4 +1,4 @@
-import { extent } from 'd3';
+import { extent } from 'd3-array';
 import flatten from 'lodash/flatten';
 import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';

--- a/src/ColorHeatmap.js
+++ b/src/ColorHeatmap.js
@@ -3,9 +3,9 @@ import {
   interpolateHsl,
   interpolateLab,
   interpolateRgb,
-  scaleLinear,
-  schemeCategory10,
-} from 'd3';
+} from 'd3-interpolate';
+import { scaleLinear } from 'd3-scale';
+import { schemeCategory10 } from 'd3-scale-chromatic';
 import isString from 'lodash/isString';
 import times from 'lodash/times';
 import range from 'lodash/range';

--- a/src/FunnelChart.js
+++ b/src/FunnelChart.js
@@ -1,4 +1,6 @@
-import { area, scaleOrdinal, schemeCategory10 } from 'd3';
+import { area } from 'd3-shape';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeCategory10 } from 'd3-scale-chromatic';
 import range from 'lodash/range';
 import defaults from 'lodash/defaults';
 import PropTypes from 'prop-types';

--- a/src/Histogram.js
+++ b/src/Histogram.js
@@ -1,4 +1,5 @@
-import { extent, histogram, scaleLinear } from 'd3';
+import { histogram, extent } from 'd3-array';
+import { scaleLinear } from 'd3-scale';
 import first from 'lodash/first';
 import last from 'lodash/last';
 import maxBy from 'lodash/maxBy';

--- a/src/KernelDensityEstimation.js
+++ b/src/KernelDensityEstimation.js
@@ -1,4 +1,4 @@
-import { mean } from 'd3';
+import { mean } from 'd3-array';
 import PropTypes from 'prop-types';
 import React from 'react';
 import LineChart from './LineChart.js';

--- a/src/LineChart.js
+++ b/src/LineChart.js
@@ -1,4 +1,6 @@
-import { bisector, line, curveLinear } from 'd3';
+import { line, curveLinear } from 'd3-shape';
+import { bisector } from 'd3-array';
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import * as CustomPropTypes from './utils/CustomPropTypes';

--- a/src/TreeMapNode.js
+++ b/src/TreeMapNode.js
@@ -39,8 +39,8 @@ const TreeMapNode = props => {
   const customStyle = isFunction(nodeStyle)
     ? nodeStyle(node)
     : isObject(nodeStyle)
-      ? nodeStyle
-      : {};
+    ? nodeStyle
+    : {};
   Object.assign(style, customStyle);
 
   const handlers = [

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -1,4 +1,5 @@
-import * as d3 from 'd3';
+import { select } from 'd3-selection';
+import { zoom, zoomIdentity, zoomTransform } from 'd3-zoom';
 import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,9 +8,7 @@ import React from 'react';
 
 function zoomTransformFromProps(props) {
   const { zoomScale, zoomX, zoomY } = props;
-  return d3.zoomIdentity
-    .translate(zoomX || 0, zoomY || 0)
-    .scale(zoomScale || 1);
+  return zoomIdentity.translate(zoomX || 0, zoomY || 0).scale(zoomScale || 1);
 }
 
 /**
@@ -130,9 +129,9 @@ export default class ZoomContainer extends React.Component {
 
   componentDidMount() {
     const initialZoomTransform = zoomTransformFromProps(this.props);
-    const selection = d3.select(this.svgRef.current);
+    const selection = select(this.svgRef.current);
 
-    this.zoom = d3.zoom();
+    this.zoom = zoom();
     selection.call(this.zoom);
 
     if (this.props.disableMouseWheelZoom) {
@@ -177,8 +176,8 @@ export default class ZoomContainer extends React.Component {
     this._updateZoomProps(nextProps);
   }
 
-  handleZoom = (...args) => {
-    const nextZoomTransform = d3.event.transform;
+  handleZoom = (event, ...args) => {
+    const nextZoomTransform = event.transform;
 
     if (this.props.controlled) {
       // zoom transform should be controlled by props, but d3-zoom has already applied new transform to this.zoom
@@ -230,9 +229,9 @@ export default class ZoomContainer extends React.Component {
   }
 
   render() {
-    const zoomTransform =
+    const theZoomTransform =
       this.svgRef && this.svgRef.current
-        ? d3.zoomTransform(this.svgRef.current)
+        ? zoomTransform(this.svgRef.current)
         : null;
 
     return (
@@ -244,7 +243,7 @@ export default class ZoomContainer extends React.Component {
         <g
           width={this.props.width}
           height={this.props.height}
-          transform={zoomTransform}
+          transform={theZoomTransform}
         >
           {this.props.children}
         </g>

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -15,7 +15,7 @@ import uniqBy from 'lodash/uniqBy';
 import has from 'lodash/has';
 import forEach from 'lodash/forEach';
 import identity from 'lodash/identity';
-import { extent } from 'd3';
+import { extent } from 'd3-array';
 import React from 'react';
 
 /**
@@ -39,8 +39,8 @@ export function makeAccessor(key) {
   return isFunction(key)
     ? key
     : isNull(key) || isUndefined(key)
-      ? identity
-      : property(key);
+    ? identity
+    : property(key);
 }
 
 /**

--- a/src/utils/Label.js
+++ b/src/utils/Label.js
@@ -6,7 +6,7 @@ import min from 'lodash/min';
 import max from 'lodash/max';
 import reduce from 'lodash/reduce';
 import identity from 'lodash/identity';
-import { timeFormat } from 'd3';
+import { timeFormat } from 'd3-time-format';
 import { format as numberFormat } from 'd3-format';
 
 export function getDefaultFormats(scaleType) {

--- a/src/utils/Scale.js
+++ b/src/utils/Scale.js
@@ -5,7 +5,13 @@ import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import isNumber from 'lodash/isNumber';
 import identity from 'lodash/identity';
-import { scaleLinear, scaleTime, scalePoint, scaleLog, scalePow } from 'd3';
+import {
+  scaleLinear,
+  scaleTime,
+  scalePoint,
+  scaleLog,
+  scalePow,
+} from 'd3-scale';
 
 import { combineDomains, domainFromData } from './Data';
 
@@ -44,22 +50,22 @@ export function inferDataTypeFromDomain(domain) {
   return domain.length !== 2
     ? 'categorical'
     : domain.every(isNumber)
-      ? 'number'
-      : domain.every(isDate)
-        ? 'time'
-        : 'categorical';
+    ? 'number'
+    : domain.every(isDate)
+    ? 'time'
+    : 'categorical';
 }
 
 export function inferScaleType(scale) {
   return !scale.ticks
     ? 'ordinal'
     : isDate(scale.domain()[0])
-      ? 'time'
-      : scale.base
-        ? 'log'
-        : scale.exponent
-          ? 'pow'
-          : 'linear';
+    ? 'time'
+    : scale.base
+    ? 'log'
+    : scale.exponent
+    ? 'pow'
+    : 'linear';
 }
 
 export function initScale(scaleType) {

--- a/tests/browser/index.js
+++ b/tests/browser/index.js
@@ -1,11 +1,11 @@
-require("./spec/XAxis.spec");
-require("./spec/YAxis.spec");
-require("./spec/YAxisLabels.spec");
-require("./spec/XAxisLabels.spec");
-require("./spec/XAxisTitle.spec");
-require("./spec/YAxisTitle.spec");
-const enzyme = require("enzyme");
-const adapter = require("enzyme-adapter-react-16");
+require('./spec/XAxis.spec');
+require('./spec/YAxis.spec');
+require('./spec/YAxisLabels.spec');
+require('./spec/XAxisLabels.spec');
+require('./spec/XAxisTitle.spec');
+require('./spec/YAxisTitle.spec');
+const enzyme = require('enzyme');
+const adapter = require('enzyme-adapter-react-16');
 
 // some tests must be run in a browser environment
 // also it can be easier to debug tests in browser thanks to chrome debugger

--- a/tests/browser/spec/XAxis.spec.js
+++ b/tests/browser/spec/XAxis.spec.js
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import {
   LineChart,
   XAxis,
@@ -10,27 +10,27 @@ import {
   XAxisTitle,
   XGrid,
   XTicks,
-  XYPlot
-} from "src/index.js";
+  XYPlot,
+} from 'src/index.js';
 
 chai.use(sinonChai);
 // XAxis tests must run in browser since XAxis uses measureText
 
-describe("XAxis", () => {
+describe('XAxis', () => {
   const width = 500;
   const height = 300;
   const props = {
     width,
     height,
-    xScaleType: "linear",
-    yScaleType: "linear",
+    xScaleType: 'linear',
+    yScaleType: 'linear',
     marginTop: 11,
     marginBottom: 22,
     marginLeft: 33,
-    marginRight: 44
+    marginRight: 44,
   };
 
-  it("extends the scale domain if to include custom `ticks` if passed", () => {
+  it('extends the scale domain if to include custom `ticks` if passed', () => {
     const tree = (
       <XYPlot {...props} xDomain={[0, 10]} yDomain={[0, 10]}>
         <LineChart data={[[0, 0], [10, 10]]} x={d => d[0]} y={d => d[1]} />
@@ -43,7 +43,7 @@ describe("XAxis", () => {
     expect(rendered.props().yDomain).to.deep.equal([0, 10]);
   });
 
-  it("rounds domain to nice numbers if `nice` option is true", () => {
+  it('rounds domain to nice numbers if `nice` option is true', () => {
     const niceXChart = mount(
       <XYPlot {...props}>
         <LineChart
@@ -52,33 +52,33 @@ describe("XAxis", () => {
           y={d => d[1]}
         />
         <XAxis nice />
-      </XYPlot>
+      </XYPlot>,
     ).find(LineChart);
 
     expect(niceXChart.props().xDomain).to.deep.equal([0, 10]);
     expect(niceXChart.props().yDomain).to.deep.equal([0.8, 9.7]);
   });
 
-  it("renders every part of the xAxis", () => {
+  it('renders every part of the xAxis', () => {
     const tree = (
       <XYPlot {...props} xDomain={[0, 10]} yDomain={[0, 10]}>
         <XAxis ticks={[-5, 0, 5]} />
       </XYPlot>
     );
     const rendered = mount(tree);
-    const line = rendered.find(".rct-chart-axis-line-x");
+    const line = rendered.find('.rct-chart-axis-line-x');
     expect(rendered.find(XGrid).props().ticks).to.have.length(3);
     expect(rendered.find(XAxisLabels)).to.have.length(1);
     expect(rendered.find(XAxisTitle)).to.have.length(1);
     expect(rendered.find(XTicks)).to.have.length(1);
     expect(line).to.have.length(1);
-    expect(line.props().x1).to.be.a("number");
-    expect(line.props().x2).to.be.a("number");
-    expect(line.props().y1).to.be.a("number");
-    expect(line.props().y2).to.be.a("number");
+    expect(line.props().x1).to.be.a('number');
+    expect(line.props().x2).to.be.a('number');
+    expect(line.props().y1).to.be.a('number');
+    expect(line.props().y2).to.be.a('number');
   });
 
-  it("handles mouse events", () => {
+  it('handles mouse events', () => {
     const onMouseEnterAxis = sinon.spy();
     const onMouseLeaveAxis = sinon.spy();
     const onMouseClickAxis = sinon.spy();
@@ -97,15 +97,15 @@ describe("XAxis", () => {
     const xAxis = rendered.find(XAxis);
 
     expect(onMouseEnterAxis).not.to.have.been.called;
-    xAxis.simulate("mouseenter");
+    xAxis.simulate('mouseenter');
     expect(onMouseEnterAxis).to.have.been.calledOnce;
 
     expect(onMouseLeaveAxis).not.to.have.been.called;
-    xAxis.simulate("mouseleave");
+    xAxis.simulate('mouseleave');
     expect(onMouseLeaveAxis).to.have.been.calledOnce;
 
     expect(onMouseClickAxis).not.to.have.been.called;
-    xAxis.simulate("click");
+    xAxis.simulate('click');
     expect(onMouseClickAxis).to.have.been.calledOnce;
   });
 });

--- a/tests/browser/spec/XAxisLabels.spec.js
+++ b/tests/browser/spec/XAxisLabels.spec.js
@@ -1,21 +1,21 @@
-import chai, { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
-import { XAxisLabels, XYPlot } from "src/index.js";
+import chai, { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { XAxisLabels, XYPlot } from 'src/index.js';
 chai.use(sinonChai);
 
 // XAxisLabels tests must run in browser since XAxisLabels uses measureText
 
-describe("XAxisLabel", () => {
-  it("Check how many labels are created and where", () => {
-    const chartStyle = { marginBottom: "10px" };
+describe('XAxisLabel', () => {
+  it('Check how many labels are created and where', () => {
+    const chartStyle = { marginBottom: '10px' };
     const functions = {
       onMouseEnterLabel: sinon.spy(),
       onMouseMoveLabel: sinon.spy(),
       onMouseLeaveLabel: sinon.spy(),
-      onMouseClickLabel: sinon.spy()
+      onMouseClickLabel: sinon.spy(),
     };
     const tree = (
       <div>
@@ -35,42 +35,42 @@ describe("XAxisLabel", () => {
     const rendered = mount(tree).find(XAxisLabels);
     const first = rendered.first();
     // each tick is a g and there's a wrapper around all g's, hence the 10 and 6
-    expect(first.find("g")).to.have.length(10);
-    expect(rendered.at(1).find("g")).to.have.length(6);
+    expect(first.find('g')).to.have.length(10);
+    expect(rendered.at(1).find('g')).to.have.length(6);
 
-    expect(rendered.at(1).props().position).to.equal("top");
-    expect(first.props().position).to.equal("bottom");
+    expect(rendered.at(1).props().position).to.equal('top');
+    expect(first.props().position).to.equal('bottom');
 
-    const firstChild = first.find("g").at(2);
+    const firstChild = first.find('g').at(2);
 
     expect(first.props().onMouseEnterLabel).not.to.have.been.called;
-    firstChild.simulate("mouseenter");
+    firstChild.simulate('mouseenter');
     expect(first.props().onMouseEnterLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseMoveLabel).not.to.have.been.called;
-    firstChild.simulate("mousemove");
+    firstChild.simulate('mousemove');
     expect(first.props().onMouseMoveLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseLeaveLabel).not.to.have.been.called;
-    firstChild.simulate("mouseleave");
+    firstChild.simulate('mouseleave');
     expect(first.props().onMouseLeaveLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseClickLabel).not.to.have.been.called;
-    firstChild.simulate("click");
+    firstChild.simulate('click');
     expect(first.props().onMouseClickLabel).to.have.been.calledOnce;
   });
 
-  it("Renders labels with given format and styles", () => {
+  it('Renders labels with given format and styles', () => {
     const tree = (
       <XYPlot width={400} height={150} xDomain={[-20, 20]} yDomain={[-20, 20]}>
         <XAxisLabels
-          format={d => `${d  }%`}
+          format={d => `${d}%`}
           position="top"
           distance={2}
           tickCount={5}
           labelStyle={label => {
             return {
-              fill: label.text === "0%" ? "green" : "blue"
+              fill: label.text === '0%' ? 'green' : 'blue',
             };
           }}
         />
@@ -78,10 +78,10 @@ describe("XAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(XAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
-    const correctTickLabels = ["-20%", "-10%", "0%", "10%", "20%"];
+    const correctTickLabels = ['-20%', '-10%', '0%', '10%', '20%'];
 
     const renderedTickLabels = labels.map(label => {
       const instance = label.instance();
@@ -89,14 +89,14 @@ describe("XAxisLabel", () => {
       const expectedStyles = Object.assign(
         XAxisLabels.defaultProps.labelStyle,
         {
-          fill: textContent === "0%" ? "green" : "blue"
-        }
+          fill: textContent === '0%' ? 'green' : 'blue',
+        },
       );
 
       Object.keys(expectedStyles).forEach(styleKey => {
         // Parse to int if lineHeight
         const styleValue =
-          styleKey === "lineHeight"
+          styleKey === 'lineHeight'
             ? parseInt(instance.style[styleKey], 10)
             : instance.style[styleKey];
 
@@ -109,16 +109,16 @@ describe("XAxisLabel", () => {
     expect(renderedTickLabels).to.eql(correctTickLabels);
   });
 
-  it("Renders date labels given formats array", () => {
+  it('Renders date labels given formats array', () => {
     const tree = (
       <XYPlot
         width={400}
         height={150}
-        xDomain={[new Date("01/01/2015"), new Date("01/01/2019")]}
+        xDomain={[new Date('01/01/2015'), new Date('01/01/2019')]}
         yDomain={[-20, 20]}
       >
         <XAxisLabels
-          formats={["%B %d, %Y", "%m/%Y"]}
+          formats={['%B %d, %Y', '%m/%Y']}
           position="top"
           distance={2}
           tickCount={5}
@@ -127,17 +127,17 @@ describe("XAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(XAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
     // Logic should pick the "%m/%Y" format since "%B %d, %Y"
     // which would format the labels like so January 30, 2015, would have too many collisions when rendered
     const correctTickLabels = [
-      "01/2015",
-      "01/2016",
-      "01/2017",
-      "01/2018",
-      "01/2019"
+      '01/2015',
+      '01/2016',
+      '01/2017',
+      '01/2018',
+      '01/2019',
     ];
 
     const renderedTickLabels = labels.map(label => {
@@ -149,11 +149,11 @@ describe("XAxisLabel", () => {
     expect(renderedTickLabels).to.eql(correctTickLabels);
   });
 
-  it("Renders number labels given formats array", () => {
+  it('Renders number labels given formats array', () => {
     const tree = (
       <XYPlot width={400} height={150} xDomain={[-1, 1]} yDomain={[-20, 20]}>
         <XAxisLabels
-          formats={["+20", ".0%"]}
+          formats={['+20', '.0%']}
           position="top"
           distance={2}
           tickCount={5}
@@ -162,12 +162,12 @@ describe("XAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(XAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
     // Logic should pick the ".0%" format since "+20"
     // would have too many collisions when rendered
-    const correctTickLabels = ["-100%", "-50%", "0%", "50%", "100%"];
+    const correctTickLabels = ['-100%', '-50%', '0%', '50%', '100%'];
 
     const renderedTickLabels = labels.map(label => {
       const instance = label.instance();

--- a/tests/browser/spec/XAxisTitle.spec.js
+++ b/tests/browser/spec/XAxisTitle.spec.js
@@ -1,19 +1,19 @@
-import chai, { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinonChai from "sinon-chai";
-import { XAxisTitle, XYPlot } from "src/index.js";
+import chai, { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinonChai from 'sinon-chai';
+import { XAxisTitle, XYPlot } from 'src/index.js';
 chai.use(sinonChai);
 
 // XAxisTitle tests must run in browser since XAxisLabels uses measureText
 
-describe("XAxisTitle", () => {
-  it("Check how many labels are created and where", () => {
+describe('XAxisTitle', () => {
+  it('Check how many labels are created and where', () => {
     const xyProps = {
       width: 500,
       height: 360,
       xDomain: [0, 100],
-      yDomain: [0, 100]
+      yDomain: [0, 100],
     };
 
     const tree = (
@@ -24,12 +24,7 @@ describe("XAxisTitle", () => {
 
         <XAxisTitle title="HHHH" alignment="center" rotate />
 
-        <XAxisTitle
-          title="JJJJ"
-          alignment="left"
-          placement="above"
-          rotate
-        />
+        <XAxisTitle title="JJJJ" alignment="left" placement="above" rotate />
 
         <XAxisTitle title="MMMM" position="top" alignment="left" />
 
@@ -39,70 +34,65 @@ describe("XAxisTitle", () => {
           alignment="left"
           placement="below"
         />
-        <XAxisTitle
-          title="SSSS"
-          position="top"
-          alignment="left"
-          rotate
-        />
+        <XAxisTitle title="SSSS" position="top" alignment="left" rotate />
       </XYPlot>
     );
     const rendered = mount(tree).find(XAxisTitle);
-    expect(rendered.at(0).props().alignment).to.equal("right");
+    expect(rendered.at(0).props().alignment).to.equal('right');
     expect(
       rendered
         .at(0)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(500,220)");
-    expect(rendered.at(1).props().placement).to.equal("above");
+        .getAttribute('transform'),
+    ).to.equal('translate(500,220)');
+    expect(rendered.at(1).props().placement).to.equal('above');
     expect(
       rendered
         .at(1)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(0,210)");
+        .getAttribute('transform'),
+    ).to.equal('translate(0,210)');
     expect(rendered.at(2).props().rotate).to.equal(true);
     expect(
       rendered
         .at(2)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(250,220)");
+        .getAttribute('transform'),
+    ).to.equal('translate(250,220)');
     expect(rendered.at(3).props().rotate).to.equal(true);
     expect(
       rendered
         .at(3)
-        .find("text")
+        .find('text')
         .first()
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("rotate(-90)");
+        .getAttribute('transform'),
+    ).to.equal('rotate(-90)');
     expect(
       rendered
         .at(4)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(0,-5)");
+        .getAttribute('transform'),
+    ).to.equal('translate(0,-5)');
     expect(
       rendered
         .at(5)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(0,5)");
+        .getAttribute('transform'),
+    ).to.equal('translate(0,5)');
     expect(
       rendered
         .at(6)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(0,-5)");
+        .getAttribute('transform'),
+    ).to.equal('translate(0,-5)');
     expect(
       rendered
         .at(6)
-        .find("text")
+        .find('text')
         .first()
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("rotate(-90)");
+        .getAttribute('transform'),
+    ).to.equal('rotate(-90)');
   });
 });

--- a/tests/browser/spec/YAxis.spec.js
+++ b/tests/browser/spec/YAxis.spec.js
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import {
   LineChart,
   XYPlot,
@@ -10,29 +10,29 @@ import {
   YAxisLabels,
   YAxisTitle,
   YGrid,
-  YTicks
-} from "src/index.js";
+  YTicks,
+} from 'src/index.js';
 
 chai.use(sinonChai);
 
 // YAxis tests must run in browser since YAxis uses measureText
 
-describe("YAxis", () => {
+describe('YAxis', () => {
   const width = 500;
   const height = 300;
 
   const props = {
     width,
     height,
-    xScaleType: "linear",
-    yScaleType: "linear",
+    xScaleType: 'linear',
+    yScaleType: 'linear',
     marginTop: 11,
     marginBottom: 22,
     marginLeft: 33,
-    marginRight: 44
+    marginRight: 44,
   };
 
-  it("extends the scale domain if to include custom `ticks` if passed", () => {
+  it('extends the scale domain if to include custom `ticks` if passed', () => {
     const tree = (
       <XYPlot {...props}>
         <LineChart data={[[0, 0], [10, 10]]} x={d => d[0]} y={d => d[1]} />
@@ -44,7 +44,7 @@ describe("YAxis", () => {
     expect(rendered.props().yDomain).to.deep.equal([-5, 10]);
   });
 
-  it("rounds domain to nice numbers if `nice` option is true", () => {
+  it('rounds domain to nice numbers if `nice` option is true', () => {
     const niceXChart = mount(
       <XYPlot {...props}>
         <LineChart
@@ -53,33 +53,33 @@ describe("YAxis", () => {
           y={d => d[1]}
         />
         <YAxis nice />
-      </XYPlot>
+      </XYPlot>,
     ).find(LineChart);
 
     expect(niceXChart.props().xDomain).to.deep.equal([0.3, 9.2]);
     expect(niceXChart.props().yDomain).to.deep.equal([0, 10]);
   });
 
-  it("renders every part of the yAxis", () => {
+  it('renders every part of the yAxis', () => {
     const tree = (
       <XYPlot {...props} xDomain={[0, 10]} yDomain={[0, 10]}>
         <YAxis ticks={[-5, 0, 5]} />
       </XYPlot>
     );
     const rendered = mount(tree);
-    const line = rendered.find(".rct-chart-axis-line-y");
+    const line = rendered.find('.rct-chart-axis-line-y');
     expect(rendered.find(YGrid).props().ticks).to.have.length(3);
     expect(rendered.find(YAxisLabels)).to.have.length(1);
     expect(rendered.find(YAxisTitle)).to.have.length(1);
     expect(rendered.find(YTicks)).to.have.length(1);
     expect(line).to.have.length(1);
-    expect(line.props().x1).to.be.a("number");
-    expect(line.props().x2).to.be.a("number");
-    expect(line.props().y1).to.be.a("number");
-    expect(line.props().y2).to.be.a("number");
+    expect(line.props().x1).to.be.a('number');
+    expect(line.props().x2).to.be.a('number');
+    expect(line.props().y1).to.be.a('number');
+    expect(line.props().y2).to.be.a('number');
   });
 
-  it("handles mouse events", () => {
+  it('handles mouse events', () => {
     const onMouseEnterAxis = sinon.spy();
     const onMouseLeaveAxis = sinon.spy();
     const onMouseClickAxis = sinon.spy();
@@ -98,15 +98,15 @@ describe("YAxis", () => {
     const yAxis = rendered.find(YAxis);
 
     expect(onMouseEnterAxis).not.to.have.been.called;
-    yAxis.simulate("mouseenter");
+    yAxis.simulate('mouseenter');
     expect(onMouseEnterAxis).to.have.been.calledOnce;
 
     expect(onMouseLeaveAxis).not.to.have.been.called;
-    yAxis.simulate("mouseleave");
+    yAxis.simulate('mouseleave');
     expect(onMouseLeaveAxis).to.have.been.calledOnce;
 
     expect(onMouseClickAxis).not.to.have.been.called;
-    yAxis.simulate("click");
+    yAxis.simulate('click');
     expect(onMouseClickAxis).to.have.been.calledOnce;
   });
 });

--- a/tests/browser/spec/YAxisLabels.spec.js
+++ b/tests/browser/spec/YAxisLabels.spec.js
@@ -1,35 +1,35 @@
-import chai, { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
-import { XYPlot, YAxisLabels } from "src/index.js";
+import chai, { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { XYPlot, YAxisLabels } from 'src/index.js';
 chai.use(sinonChai);
 
 // YAxisLabels tests must run in browser since YAxisLabels uses measureText
 
-describe("YAxisLabel", () => {
+describe('YAxisLabel', () => {
   const width = 500;
   const height = 300;
   const props = {
     width,
     height,
-    xScaleType: "linear",
-    yScaleType: "linear",
+    xScaleType: 'linear',
+    yScaleType: 'linear',
     marginTop: 11,
     marginBottom: 22,
     marginLeft: 33,
     marginRight: 44,
-    offset: 5
+    offset: 5,
   };
 
-  it("Check how many labels are created and where", () => {
-    const chartStyle = { marginBottom: "10px" };
+  it('Check how many labels are created and where', () => {
+    const chartStyle = { marginBottom: '10px' };
     const functions = {
       onMouseEnterLabel: sinon.spy(),
       onMouseMoveLabel: sinon.spy(),
       onMouseLeaveLabel: sinon.spy(),
-      onMouseClickLabel: sinon.spy()
+      onMouseClickLabel: sinon.spy(),
     };
     const tree = (
       <div>
@@ -49,42 +49,42 @@ describe("YAxisLabel", () => {
     const rendered = mount(tree).find(YAxisLabels);
     const first = rendered.first();
     // each tick is a g and there's a wrapper around all g's, hence the 10 and 6
-    expect(first.find("g")).to.have.length(10);
-    expect(rendered.at(1).find("g")).to.have.length(6);
+    expect(first.find('g')).to.have.length(10);
+    expect(rendered.at(1).find('g')).to.have.length(6);
 
-    expect(rendered.at(1).props().position).to.equal("right");
-    expect(first.props().position).to.equal("left");
+    expect(rendered.at(1).props().position).to.equal('right');
+    expect(first.props().position).to.equal('left');
 
-    const firstChild = first.find("g").at(2);
+    const firstChild = first.find('g').at(2);
 
     expect(first.props().onMouseEnterLabel).not.to.have.been.called;
-    firstChild.simulate("mouseenter");
+    firstChild.simulate('mouseenter');
     expect(first.props().onMouseEnterLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseMoveLabel).not.to.have.been.called;
-    firstChild.simulate("mousemove");
+    firstChild.simulate('mousemove');
     expect(first.props().onMouseMoveLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseLeaveLabel).not.to.have.been.called;
-    firstChild.simulate("mouseleave");
+    firstChild.simulate('mouseleave');
     expect(first.props().onMouseLeaveLabel).to.have.been.calledOnce;
 
     expect(first.props().onMouseClickLabel).not.to.have.been.called;
-    firstChild.simulate("click");
+    firstChild.simulate('click');
     expect(first.props().onMouseClickLabel).to.have.been.calledOnce;
   });
 
-  it("Renders labels with given format and styles", () => {
+  it('Renders labels with given format and styles', () => {
     const tree = (
       <XYPlot width={400} height={150} xDomain={[-20, 20]} yDomain={[-20, 20]}>
         <YAxisLabels
-          format={d => `${d  }%`}
+          format={d => `${d}%`}
           position="left"
           distance={2}
           tickCount={5}
           labelStyle={label => {
             return {
-              fill: label.text === "0%" ? "green" : "blue"
+              fill: label.text === '0%' ? 'green' : 'blue',
             };
           }}
         />
@@ -92,10 +92,10 @@ describe("YAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(YAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
-    const correctTickLabels = ["-20%", "-10%", "0%", "10%", "20%"];
+    const correctTickLabels = ['-20%', '-10%', '0%', '10%', '20%'];
 
     const renderedTickLabels = labels.map(label => {
       const instance = label.instance();
@@ -103,14 +103,14 @@ describe("YAxisLabel", () => {
       const expectedStyles = Object.assign(
         YAxisLabels.defaultProps.labelStyle,
         {
-          fill: textContent === "0%" ? "green" : "blue"
-        }
+          fill: textContent === '0%' ? 'green' : 'blue',
+        },
       );
 
       Object.keys(expectedStyles).forEach(styleKey => {
         // Parse to int if lineHeight
         const styleValue =
-          styleKey === "lineHeight"
+          styleKey === 'lineHeight'
             ? parseInt(instance.style[styleKey], 10)
             : instance.style[styleKey];
 
@@ -123,16 +123,16 @@ describe("YAxisLabel", () => {
     expect(renderedTickLabels).to.eql(correctTickLabels);
   });
 
-  it("Renders date labels given formats array", () => {
+  it('Renders date labels given formats array', () => {
     const tree = (
       <XYPlot
         width={400}
         height={150}
-        yDomain={[new Date("01/01/2015"), new Date("01/01/2019")]}
+        yDomain={[new Date('01/01/2015'), new Date('01/01/2019')]}
         xDomain={[-20, 20]}
       >
         <YAxisLabels
-          formats={["%B %d, %Y", "%m/%Y"]}
+          formats={['%B %d, %Y', '%m/%Y']}
           position="left"
           distance={2}
           tickCount={5}
@@ -141,18 +141,18 @@ describe("YAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(YAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
     // Logic should pick our first format "%B %d, %Y"
     // which would format the labels like so January 30, 2015
     // because YAxisLabels (rendered vertically) wouldn't have collisions
     const correctTickLabels = [
-      "January 01, 2015",
-      "January 01, 2016",
-      "January 01, 2017",
-      "January 01, 2018",
-      "January 01, 2019"
+      'January 01, 2015',
+      'January 01, 2016',
+      'January 01, 2017',
+      'January 01, 2018',
+      'January 01, 2019',
     ];
 
     const renderedTickLabels = labels.map(label => {
@@ -164,11 +164,11 @@ describe("YAxisLabel", () => {
     expect(renderedTickLabels).to.eql(correctTickLabels);
   });
 
-  it("Renders number labels given formats array", () => {
+  it('Renders number labels given formats array', () => {
     const tree = (
       <XYPlot width={400} height={150} xDomain={[-20, 20]} yDomain={[-1, 1]}>
         <YAxisLabels
-          formats={[".1%", ".0%"]}
+          formats={['.1%', '.0%']}
           position="left"
           distance={2}
           tickCount={5}
@@ -177,13 +177,13 @@ describe("YAxisLabel", () => {
     );
 
     const rendered = mount(tree).find(YAxisLabels);
-    const labelWrapper = rendered.first("g");
-    const labels = labelWrapper.children().find("text");
+    const labelWrapper = rendered.first('g');
+    const labels = labelWrapper.children().find('text');
 
     // Logic should pick our first format ".1%"
     // which would format the labels like so: 1.0%
     // because YAxisLabels (rendered vertically) wouldn't have collisions
-    const correctTickLabels = ["-100.0%", "-50.0%", "0.0%", "50.0%", "100.0%"];
+    const correctTickLabels = ['-100.0%', '-50.0%', '0.0%', '50.0%', '100.0%'];
 
     const renderedTickLabels = labels.map(label => {
       const instance = label.instance();

--- a/tests/browser/spec/YAxisTitle.spec.js
+++ b/tests/browser/spec/YAxisTitle.spec.js
@@ -1,19 +1,19 @@
-import chai, { expect } from "chai";
-import { mount } from "enzyme";
-import React from "react";
-import sinonChai from "sinon-chai";
-import { XYPlot, YAxisTitle } from "src/index.js";
+import chai, { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import sinonChai from 'sinon-chai';
+import { XYPlot, YAxisTitle } from 'src/index.js';
 chai.use(sinonChai);
 
 // YAxisTitle tests must run in browser since XAxisLabels uses measureText
 
-describe("YAxisTitle", () => {
-  it("Check how many labels are created and where", () => {
+describe('YAxisTitle', () => {
+  it('Check how many labels are created and where', () => {
     const xyProps = {
       width: 500,
       height: 360,
       xDomain: [0, 100],
-      yDomain: [0, 100]
+      yDomain: [0, 100],
     };
 
     const tree = (
@@ -47,61 +47,61 @@ describe("YAxisTitle", () => {
       </XYPlot>
     );
     const rendered = mount(tree).find(YAxisTitle);
-    expect(rendered.at(0).props().alignment).to.equal("top");
+    expect(rendered.at(0).props().alignment).to.equal('top');
     expect(
       rendered
         .at(0)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(-5,0)");
+        .getAttribute('transform'),
+    ).to.equal('translate(-5,0)');
     expect(rendered.at(1).props().rotate).to.equal(false);
     expect(
       rendered
         .at(1)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(-5,180)");
-    expect(rendered.at(2).props().placement).to.equal("after");
+        .getAttribute('transform'),
+    ).to.equal('translate(-5,180)');
+    expect(rendered.at(2).props().placement).to.equal('after');
     expect(
       rendered
         .at(2)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(5,360)");
+        .getAttribute('transform'),
+    ).to.equal('translate(5,360)');
     expect(rendered.at(3).props().rotate).to.equal(false);
     expect(
       rendered
         .at(3)
-        .find("text")
+        .find('text')
         .first()
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("rotate(0)");
+        .getAttribute('transform'),
+    ).to.equal('rotate(0)');
     expect(
       rendered
         .at(4)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(360,0)");
+        .getAttribute('transform'),
+    ).to.equal('translate(360,0)');
     expect(
       rendered
         .at(5)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(360,360)");
+        .getAttribute('transform'),
+    ).to.equal('translate(360,360)');
     expect(
       rendered
         .at(6)
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("translate(350,180)");
+        .getAttribute('transform'),
+    ).to.equal('translate(350,180)');
     expect(
       rendered
         .at(6)
-        .find("text")
+        .find('text')
         .first()
         .getDOMNode()
-        .getAttribute("transform")
-    ).to.equal("rotate(-90)");
+        .getAttribute('transform'),
+    ).to.equal('rotate(-90)');
   });
 });

--- a/tests/jsdom/spec/AreaBarChart.spec.js
+++ b/tests/jsdom/spec/AreaBarChart.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
@@ -9,12 +9,10 @@ import { getValue } from '../../../src/utils/Data.js';
 describe('AreaBarChart', () => {
   describe('renders and passes props correctly to RangeRect', () => {
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([0, 100])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [

--- a/tests/jsdom/spec/AreaBarChart.spec.js
+++ b/tests/jsdom/spec/AreaBarChart.spec.js
@@ -1,13 +1,13 @@
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { AreaBarChart, RangeRect } from "../../../src/index.js";
-import { getValue } from "../../../src/utils/Data.js";
+import { AreaBarChart, RangeRect } from '../../../src/index.js';
+import { getValue } from '../../../src/utils/Data.js';
 
-describe("AreaBarChart", () => {
-  describe("renders and passes props correctly to RangeRect", () => {
+describe('AreaBarChart', () => {
+  describe('renders and passes props correctly to RangeRect', () => {
     const props = {
       xScale: d3
         .scaleLinear()
@@ -20,23 +20,23 @@ describe("AreaBarChart", () => {
       data: [
         { ageMin: 25, ageMax: 45, rate: 0.25 },
         { ageMin: 45, ageMax: 65, rate: 0.17 },
-        { ageMin: 65, ageMax: 85, rate: 0.084 }
+        { ageMin: 65, ageMax: 85, rate: 0.084 },
       ],
       x: d => d.ageMin,
       xEnd: d => d.ageMax,
       y: () => 0,
       yEnd: d => d.rate,
-      barClassName: "test-bar-class-name",
-      barStyle: { fill: "red" },
+      barClassName: 'test-bar-class-name',
+      barStyle: { fill: 'red' },
       onMouseEnterBar: () => {},
       onMouseMoveBar: () => {},
-      onMouseLeaveBar: () => {}
+      onMouseLeaveBar: () => {},
     };
 
-    it("when horizontal is false", () => {
+    it('when horizontal is false', () => {
       // renders individual RangeRects for the length of data
       const chart = mount(<AreaBarChart {...props} />);
-      const group = chart.find("g");
+      const group = chart.find('g');
       const rangeRects = chart.find(RangeRect);
       expect(group).to.have.length(1);
       expect(rangeRects).to.have.length(props.data.length);
@@ -47,33 +47,35 @@ describe("AreaBarChart", () => {
       expect(rangeRects.at(0).props().className).to.contain(props.barClassName);
       expect(rangeRects.at(0).props().style).to.equal(props.barStyle);
       expect(rangeRects.at(0).props().x).to.equal(
-        getValue(props.x, props.data[0])
+        getValue(props.x, props.data[0]),
       );
       expect(rangeRects.at(0).props().xEnd).to.equal(
-        getValue(props.xEnd, props.data[0])
+        getValue(props.xEnd, props.data[0]),
       );
       expect(rangeRects.at(0).props().y).to.equal(0);
       expect(rangeRects.at(0).props().yEnd).to.equal(
-        getValue(props.y, props.data[0])
+        getValue(props.y, props.data[0]),
       );
     });
 
-    it("when horizontal is true", () => {
+    it('when horizontal is true', () => {
       // check that correct props are passed through in horizontal case
       const horizontalProps = { ...props, horizontal: true };
 
-      const horizontalAreaBarChart = mount(<AreaBarChart {...horizontalProps} />);
+      const horizontalAreaBarChart = mount(
+        <AreaBarChart {...horizontalProps} />,
+      );
       const horizontalRangeRects = horizontalAreaBarChart.find(RangeRect);
 
       expect(horizontalRangeRects.at(0).props().x).to.equal(0);
       expect(horizontalRangeRects.at(0).props().xEnd).to.equal(
-        getValue(props.x, props.data[0])
+        getValue(props.x, props.data[0]),
       );
       expect(horizontalRangeRects.at(0).props().y).to.equal(
-        getValue(props.y, props.data[0])
+        getValue(props.y, props.data[0]),
       );
       expect(horizontalRangeRects.at(0).props().yEnd).to.equal(
-        getValue(props.yEnd, props.data[0])
+        getValue(props.yEnd, props.data[0]),
       );
     });
   });

--- a/tests/jsdom/spec/AreaChart.spec.js
+++ b/tests/jsdom/spec/AreaChart.spec.js
@@ -1,11 +1,11 @@
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
-import { mount } from "enzyme";
-import _ from "lodash";
-import { AreaChart } from "../../../src/index.js";
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import _ from 'lodash';
+import { AreaChart } from '../../../src/index.js';
 
-import { combineDatasets } from "../../../src/utils/Data.js";
+import { combineDatasets } from '../../../src/utils/Data.js';
 
 function randomWalk(length = 100, start = 0, variance = 10) {
   return _.reduce(
@@ -13,7 +13,7 @@ function randomWalk(length = 100, start = 0, variance = 10) {
     (sequence, i) => {
       return sequence.concat(_.last(sequence) + _.random(-variance, variance));
     },
-    [start]
+    [start],
   );
 }
 
@@ -21,7 +21,7 @@ function randomWalkTimeSeries(
   length = 100,
   start = 0,
   variance = 10,
-  startDate = new Date(2015, 0, 1)
+  startDate = new Date(2015, 0, 1),
 ) {
   let date = startDate;
   return randomWalk(length, start, variance).map((n, i) => {
@@ -30,16 +30,16 @@ function randomWalkTimeSeries(
   });
 }
 
-describe("AreaChart", () => {
+describe('AreaChart', () => {
   const areaChartProps = {
     data: _.range(41),
     x: d => d,
     y: d => Math.sin(d / 10) * 10,
     yEnd: d => Math.cos((d + 1) / 10) * 10,
-    pathClassName: "my-path",
+    pathClassName: 'my-path',
     xScale: d3.scaleLinear().domain([0, 41]),
     yScale: d3.scaleLinear().domain([0, 10]),
-    pathStyle: { fill: "red" }
+    pathStyle: { fill: 'red' },
   };
 
   const data1 = randomWalkTimeSeries(115).map(([x, y]) => ({ x, y }));
@@ -50,79 +50,79 @@ describe("AreaChart", () => {
   // (from 'reactochart/utils/Data')
   const combined = combineDatasets(
     [
-      { data: data1, combineKey: "x", dataKeys: { y: "y0" } },
-      { data: data2, combineKey: "x", dataKeys: { y: "y1" } }
+      { data: data1, combineKey: 'x', dataKeys: { y: 'y0' } },
+      { data: data2, combineKey: 'x', dataKeys: { y: 'y1' } },
     ],
-    "x"
+    'x',
   );
 
   const differenceAreaChartProps = {
     data: combined,
     isDifference: true,
-    pathStylePositive: { fill: "blue" },
-    pathStyleNegative: { fill: "green" },
+    pathStylePositive: { fill: 'blue' },
+    pathStyleNegative: { fill: 'green' },
     x: d => d.x,
     y: d => d.y0,
-    yEnd: d => d.y1
+    yEnd: d => d.y1,
   };
 
-  it("passes props correctly to path", () => {
+  it('passes props correctly to path', () => {
     let chart = mount(<AreaChart {...areaChartProps} />);
-    let path = chart.find("path");
+    let path = chart.find('path');
 
-    expect(path.props().className).to.contain("my-path");
+    expect(path.props().className).to.contain('my-path');
     expect(path.props().style).to.equal(areaChartProps.pathStyle);
 
     chart = mount(
-      <AreaChart {...areaChartProps} {...differenceAreaChartProps} />
+      <AreaChart {...areaChartProps} {...differenceAreaChartProps} />,
     );
-    path = chart.find("path");
+    path = chart.find('path');
 
     path.forEach((p, index) => {
       if (index < 2) {
         expect(p.props().className).to.not.contain(
-          areaChartProps.pathClassName
+          areaChartProps.pathClassName,
         );
       } else if (index == 3) {
         expect(p.props().style.fill).to.equal(
-          differenceAreaChartProps.pathStyleNegative.fill
+          differenceAreaChartProps.pathStyleNegative.fill,
         );
         expect(p.props().className).to.contain(areaChartProps.pathClassName);
       } else {
         expect(p.props().style.fill).to.equal(
-          differenceAreaChartProps.pathStylePositive.fill
+          differenceAreaChartProps.pathStylePositive.fill,
         );
         expect(p.props().className).to.contain(areaChartProps.pathClassName);
       }
     });
   });
 
-  it("renders the expected group and the expected number of paths", () => {
+  it('renders the expected group and the expected number of paths', () => {
     let chart = mount(<AreaChart {...areaChartProps} />);
-    let path = chart.find("path");
-    let group = chart.find("g");
+    let path = chart.find('path');
+    let group = chart.find('g');
 
     expect(group.length).to.equal(1);
-    expect(group.props().className).to.equal("rct-area-chart");
+    expect(group.props().className).to.equal('rct-area-chart');
     expect(path.length).to.equal(1);
 
     chart = mount(
-      <AreaChart {...areaChartProps} {...differenceAreaChartProps} />
+      <AreaChart {...areaChartProps} {...differenceAreaChartProps} />,
     );
-    path = chart.find("path");
-    group = chart.find("g");
+    path = chart.find('path');
+    group = chart.find('g');
 
     expect(group.length).to.equal(1);
-    expect(group.props().className).to.equal("rct-area-chart--difference");
+    expect(group.props().className).to.equal('rct-area-chart--difference');
     expect(path.length).to.equal(4);
   });
 
-  it("getDomain returns correctly", () => {
+  it('getDomain returns correctly', () => {
     const domainProps = {
       data: _.range(10),
       x: () => x,
       y: () => 0,
-      yEnd: d => d + 2
+      yEnd: d => d + 2,
     };
     const domain = { yDomain: [0, 11] };
 

--- a/tests/jsdom/spec/AreaChart.spec.js
+++ b/tests/jsdom/spec/AreaChart.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import _ from 'lodash';
@@ -10,7 +10,7 @@ import { combineDatasets } from '../../../src/utils/Data.js';
 function randomWalk(length = 100, start = 0, variance = 10) {
   return _.reduce(
     _.range(length - 1),
-    (sequence, i) => {
+    sequence => {
       return sequence.concat(_.last(sequence) + _.random(-variance, variance));
     },
     [start],
@@ -24,7 +24,7 @@ function randomWalkTimeSeries(
   startDate = new Date(2015, 0, 1),
 ) {
   let date = startDate;
-  return randomWalk(length, start, variance).map((n, i) => {
+  return randomWalk(length, start, variance).map(n => {
     date = new Date(date.getTime() + 24 * 60 * 60 * 1000);
     return [date, n];
   });
@@ -37,8 +37,8 @@ describe('AreaChart', () => {
     y: d => Math.sin(d / 10) * 10,
     yEnd: d => Math.cos((d + 1) / 10) * 10,
     pathClassName: 'my-path',
-    xScale: d3.scaleLinear().domain([0, 41]),
-    yScale: d3.scaleLinear().domain([0, 10]),
+    xScale: scaleLinear().domain([0, 41]),
+    yScale: scaleLinear().domain([0, 10]),
     pathStyle: { fill: 'red' },
   };
 
@@ -83,7 +83,7 @@ describe('AreaChart', () => {
         expect(p.props().className).to.not.contain(
           areaChartProps.pathClassName,
         );
-      } else if (index == 3) {
+      } else if (index === 3) {
         expect(p.props().style.fill).to.equal(
           differenceAreaChartProps.pathStyleNegative.fill,
         );
@@ -120,7 +120,7 @@ describe('AreaChart', () => {
   it('getDomain returns correctly', () => {
     const domainProps = {
       data: _.range(10),
-      x: () => x,
+      x: x => x,
       y: () => 0,
       yEnd: d => d + 2,
     };

--- a/tests/jsdom/spec/AreaHeatmap.spec.js
+++ b/tests/jsdom/spec/AreaHeatmap.spec.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import _ from 'lodash';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
 import { AreaHeatmap } from '../../../src/index.js';
-import { getValue } from '../../../src/utils/Data.js';
 
 describe('AreaHeatmap', () => {
   const gridData = _.range(30).map(m => {
@@ -29,12 +28,10 @@ describe('AreaHeatmap', () => {
     y: d => d.y,
     yEnd: d => d.yEnd,
     rectClassName: 'rect-class',
-    xScale: d3
-      .scaleLinear()
+    xScale: scaleLinear()
       .domain([-1, 0, 1])
       .range([0, 30]),
-    yScale: d3
-      .scaleLinear()
+    yScale: scaleLinear()
       .domain([0, 10])
       .range([0, 30]),
     onMouseMove: sinon.spy(),

--- a/tests/jsdom/spec/AreaHeatmap.spec.js
+++ b/tests/jsdom/spec/AreaHeatmap.spec.js
@@ -1,14 +1,14 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import sinon from "sinon";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { AreaHeatmap } from "../../../src/index.js";
-import { getValue } from "../../../src/utils/Data.js";
+import { AreaHeatmap } from '../../../src/index.js';
+import { getValue } from '../../../src/utils/Data.js';
 
-describe("AreaHeatmap", () => {
+describe('AreaHeatmap', () => {
   const gridData = _.range(30).map(m => {
     return _.range(30).map(n => {
       return {
@@ -16,7 +16,7 @@ describe("AreaHeatmap", () => {
         xEnd: n + 1,
         y: m,
         yEnd: m + 1,
-        value: Math.sin(m * n * 0.01)
+        value: Math.sin(m * n * 0.01),
       };
     });
   });
@@ -28,7 +28,7 @@ describe("AreaHeatmap", () => {
     xEnd: d => d.xEnd,
     y: d => d.y,
     yEnd: d => d.yEnd,
-    rectClassName: "rect-class",
+    rectClassName: 'rect-class',
     xScale: d3
       .scaleLinear()
       .domain([-1, 0, 1])
@@ -40,42 +40,42 @@ describe("AreaHeatmap", () => {
     onMouseMove: sinon.spy(),
     onMouseEnter: sinon.spy(),
     onMouseLeave: sinon.spy(),
-    rectStyle: { fill: "rebeccapurple" }
+    rectStyle: { fill: 'rebeccapurple' },
   };
 
-  it("renders a color heatmap", () => {
+  it('renders a color heatmap', () => {
     const chart = mount(<AreaHeatmap {...props} />);
-    const group = chart.find("g.rct-area-heatmap-chart");
+    const group = chart.find('g.rct-area-heatmap-chart');
     expect(group).to.have.length(1);
-    expect(group.find("rect")).to.have.lengthOf.above(1);
+    expect(group.find('rect')).to.have.lengthOf.above(1);
   });
 
-  it("passes props correctly", () => {
+  it('passes props correctly', () => {
     const chart = mount(<AreaHeatmap {...props} />);
-    const lastRect = chart.find("rect").last();
+    const lastRect = chart.find('rect').last();
 
-    expect(chart.props().onMouseMove).to.be.a("function");
-    expect(chart.props().onMouseEnter).to.be.a("function");
-    expect(chart.props().onMouseLeave).to.be.a("function");
+    expect(chart.props().onMouseMove).to.be.a('function');
+    expect(chart.props().onMouseEnter).to.be.a('function');
+    expect(chart.props().onMouseLeave).to.be.a('function');
 
-    expect(lastRect.props().x).to.be.a("number");
-    expect(lastRect.props().y).to.be.a("number");
-    expect(lastRect.props().width).to.be.a("number");
-    expect(lastRect.props().height).to.be.a("number");
+    expect(lastRect.props().x).to.be.a('number');
+    expect(lastRect.props().y).to.be.a('number');
+    expect(lastRect.props().width).to.be.a('number');
+    expect(lastRect.props().height).to.be.a('number');
     expect(lastRect.props().className).to.include(props.rectClassName);
     expect(lastRect.props().style).to.equal(props.rectStyle);
   });
 
-  it("triggers event handlers", () => {
+  it('triggers event handlers', () => {
     const chart = mount(<AreaHeatmap {...props} />);
     expect(chart.props().onMouseMove).not.to.have.been.called;
-    chart.simulate("mousemove");
+    chart.simulate('mousemove');
     expect(chart.props().onMouseMove).to.have.been.called;
     expect(chart.props().onMouseEnter).not.to.have.been.called;
-    chart.simulate("mouseenter");
+    chart.simulate('mouseenter');
     expect(chart.props().onMouseEnter).to.have.been.called;
     expect(chart.props().onMouseLeave).not.to.have.been.called;
-    chart.simulate("mouseleave");
+    chart.simulate('mouseleave');
     expect(chart.props().onMouseLeave).to.have.been.called;
   });
 });

--- a/tests/jsdom/spec/Bar.spec.js
+++ b/tests/jsdom/spec/Bar.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scalePoint, scaleLinear } from 'd3-scale';
 import chai from 'chai';
 import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
@@ -15,12 +15,10 @@ describe('Bar', () => {
 
   beforeEach(() => {
     verticalBarProps = {
-      xScale: d3
-        .scalePoint()
+      xScale: scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       x: 'a',
@@ -30,12 +28,10 @@ describe('Bar', () => {
     };
 
     horizontalBarProps = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([0, 1])
         .range([0, 100]),
-      yScale: d3
-        .scalePoint()
+      yScale: scalePoint()
         .domain(['a', 'b', 'c'])
         .range([100, 0]),
       x: 0.2,
@@ -48,12 +44,10 @@ describe('Bar', () => {
   it('renders a basic vertical bar correctly', () => {
     const bar = shallow(
       <Bar
-        xScale={d3
-          .scalePoint()
+        xScale={scalePoint()
           .domain(['a', 'b', 'c'])
           .range([0, 100])}
-        yScale={d3
-          .scaleLinear()
+        yScale={scaleLinear()
           .domain([0, 1])
           .range([100, 0])}
         x="b"
@@ -78,12 +72,10 @@ describe('Bar', () => {
   it('renders a basic horizontal bar correctly', () => {
     const bar = shallow(
       <Bar
-        xScale={d3
-          .scaleLinear()
+        xScale={scaleLinear()
           .domain([0, 1])
           .range([0, 100])}
-        yScale={d3
-          .scalePoint()
+        yScale={scalePoint()
           .domain(['a', 'b', 'c'])
           .range([100, 0])}
         x={0.1}
@@ -172,12 +164,10 @@ describe('Bar', () => {
 
   it('throws an error if x/y scale(s) are missing or invalid', () => {
     const barProps = { x: 'a', y: 0, yEnd: 1 };
-    const xScale = d3
-      .scalePoint()
+    const xScale = scalePoint()
       .domain(['a', 'b', 'c'])
       .range([0, 100]);
-    const yScale = d3
-      .scaleLinear()
+    const yScale = scaleLinear()
       .domain([0, 1])
       .range([100, 0]);
 
@@ -197,12 +187,10 @@ describe('Bar', () => {
 
   it('throws an error if exactly ONE of xEnd OR yEnd are not provided', () => {
     const barProps = {
-      xScale: d3
-        .scalePoint()
+      xScale: scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       x: 'a',

--- a/tests/jsdom/spec/BarChart.spec.js
+++ b/tests/jsdom/spec/BarChart.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint } from 'd3-scale';
 import _ from 'lodash';
 import { expect } from 'chai';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { testWithScales, expectProps } from '../utils';
 import { BarChart, RangeBarChart } from '../../../src/index.js';
@@ -11,12 +11,10 @@ describe('BarChart', () => {
   it('passes most props through to RangeBarChart', () => {
     // bar chart is just a simple wrapper around RangeBarChart, most props are passed through
     const props = {
-      xScale: d3
-        .scalePoint()
+      xScale: scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [['a', 0.25], ['b', 0.5], ['c', 0.67]],

--- a/tests/jsdom/spec/BarChart.spec.js
+++ b/tests/jsdom/spec/BarChart.spec.js
@@ -1,41 +1,41 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import { mount, shallow } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
 
-import { testWithScales, expectProps } from "../utils";
-import { BarChart, RangeBarChart } from "../../../src/index.js";
+import { testWithScales, expectProps } from '../utils';
+import { BarChart, RangeBarChart } from '../../../src/index.js';
 
-describe("BarChart", () => {
-  it("passes most props through to RangeBarChart", () => {
+describe('BarChart', () => {
+  it('passes most props through to RangeBarChart', () => {
     // bar chart is just a simple wrapper around RangeBarChart, most props are passed through
     const props = {
       xScale: d3
         .scalePoint()
-        .domain(["a", "b", "c"])
+        .domain(['a', 'b', 'c'])
         .range([0, 100]),
       yScale: d3
         .scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
-      data: [["a", 0.25], ["b", 0.5], ["c", 0.67]],
+      data: [['a', 0.25], ['b', 0.5], ['c', 0.67]],
       x: d => d[0],
       y: d => d[1],
       barThickness: 13,
       horizontal: false,
-      barClassName: "test-bar-class-name",
-      barStyle: { fill: "red" },
-      getClass: () => "test",
-      onMouseEnterBar: () => "onMouseEnterBar",
-      onMouseMoveBar: () => "onMouseMoveBar",
-      onMouseLeaveBar: () => "onMouseLeaveBar"
+      barClassName: 'test-bar-class-name',
+      barStyle: { fill: 'red' },
+      getClass: () => 'test',
+      onMouseEnterBar: () => 'onMouseEnterBar',
+      onMouseMoveBar: () => 'onMouseMoveBar',
+      onMouseLeaveBar: () => 'onMouseLeaveBar',
     };
 
     const chart = mount(<BarChart {...props} />);
     const rangeBarChart = chart.find(RangeBarChart);
     // all props should be passed through as-is *except* y
-    expectProps(rangeBarChart, _.omit(props, ["y"]));
+    expectProps(rangeBarChart, _.omit(props, ['y']));
 
     // vertical bar chart - y is passed to RangeBarChart as yEnd
     expect(rangeBarChart.props().yEnd).to.equal(props.y);
@@ -47,22 +47,22 @@ describe("BarChart", () => {
     const horizontalRangeBarChart = horizontalChart.find(RangeBarChart);
 
     // all props should be passed through as-is *except* x
-    expectProps(horizontalRangeBarChart, _.omit(horizontalProps, ["x"]));
+    expectProps(horizontalRangeBarChart, _.omit(horizontalProps, ['x']));
 
     // vertical bar chart - x is passed to RangeBarChart as xEnd
     expect(horizontalRangeBarChart.props().xEnd).to.equal(horizontalProps.x);
   });
 
-  it("renders a bar chart with categorical X data & numerical Y data", () => {
+  it('renders a bar chart with categorical X data & numerical Y data', () => {
     // make simple bar chart with 3 datapoints to make sure it renders correctly
     // this is more of an integration test/sanity check;
     // most tests for render correctness are in RangeBarChart and Bar specs
 
     testWithScales(
-      ["linear", "ordinal"],
+      ['linear', 'ordinal'],
       ({ scale: xScale, testValues: xTestValues }) => {
         testWithScales(
-          ["linear"],
+          ['linear'],
           ({ scale: yScale, testValues: yTestValues }) => {
             const props = {
               xScale,
@@ -70,19 +70,19 @@ describe("BarChart", () => {
               data: _.zip(_.take(xTestValues, 3), _.take(yTestValues, 3)),
               x: d => d[0],
               y: d => d[1],
-              barThickness: 10
+              barThickness: 10,
             };
 
             const chart = mount(<BarChart {...props} />);
-            const group = chart.find("g");
-            const bars = chart.find("rect");
+            const group = chart.find('g');
+            const bars = chart.find('rect');
             expect(group).to.have.length(1);
             expect(bars).to.have.length(3);
 
             [0, 1, 2].forEach(i => {
               const barProps = bars.at(i).props();
               expect(barProps.x).to.equal(
-                xScale(xTestValues[i]) - props.barThickness / 2
+                xScale(xTestValues[i]) - props.barThickness / 2,
               );
               expect(barProps.width).to.equal(props.barThickness);
               const yZero = yScale(0);
@@ -90,9 +90,9 @@ describe("BarChart", () => {
               expect(barProps.y).to.equal(Math.min(yZero, yVal));
               expect(barProps.height).to.equal(Math.abs(yVal - yZero));
             });
-          }
+          },
         );
-      }
+      },
     );
   });
 });

--- a/tests/jsdom/spec/ColorHeatmap.spec.js
+++ b/tests/jsdom/spec/ColorHeatmap.spec.js
@@ -1,13 +1,13 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { XYPlot, ColorHeatmap, RangeRect } from "../../../src/index.js";
-import { getValue } from "../../../src/utils/Data.js";
+import { XYPlot, ColorHeatmap, RangeRect } from '../../../src/index.js';
+import { getValue } from '../../../src/utils/Data.js';
 
-describe("ColorHeatmap", () => {
+describe('ColorHeatmap', () => {
   const gridData = _.range(30).map(m => {
     return _.range(30).map(n => {
       return {
@@ -15,7 +15,7 @@ describe("ColorHeatmap", () => {
         xEnd: n + 1,
         y: m,
         yEnd: m + 1,
-        value: Math.sin(m * n * 0.01)
+        value: Math.sin(m * n * 0.01),
       };
     });
   });
@@ -35,75 +35,75 @@ describe("ColorHeatmap", () => {
       .scaleLinear()
       .domain([0, 10])
       .range([0, 30]),
-    colors: ["rebeccapurple", "goldenrod"],
-    interpolator: "lab",
-    rectClassName: "rect-class"
+    colors: ['rebeccapurple', 'goldenrod'],
+    interpolator: 'lab',
+    rectClassName: 'rect-class',
   };
 
-  it("renders a color heatmap", () => {
+  it('renders a color heatmap', () => {
     const chart = mount(<ColorHeatmap {...props} />);
-    const group = chart.find("g");
+    const group = chart.find('g');
     const rangeRects = chart.find(RangeRect);
     expect(rangeRects).to.have.length(props.data.length);
   });
 
-  it("passes props correctly", () => {
+  it('passes props correctly', () => {
     const chart = mount(<ColorHeatmap {...props} />);
 
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().x
+        .props().x,
     ).to.equal(getValue(props.x, props.data[0]));
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().xEnd
+        .props().xEnd,
     ).to.equal(getValue(props.xEnd, props.data[0]));
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().y
+        .props().y,
     ).to.equal(getValue(props.y, props.data[0]));
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().yEnd
+        .props().yEnd,
     ).to.equal(getValue(props.yEnd, props.data[0]));
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().xScale
+        .props().xScale,
     ).to.equal(props.xScale);
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().yScale
+        .props().yScale,
     ).to.equal(props.yScale);
     expect(
       chart
         .find(RangeRect)
         .first()
-        .props().className
+        .props().className,
     ).to.equal(props.rectClassName);
 
-    describe("when colorScale prop is passed", () => {
-      it("sets the color scale to the prop value", () => {
-        const propsWithColorScale = { ...props, colorScale: () => "rgb" };
+    describe('when colorScale prop is passed', () => {
+      it('sets the color scale to the prop value', () => {
+        const propsWithColorScale = { ...props, colorScale: () => 'rgb' };
         const chart = mount(<ColorHeatmap {...propsWithColorScale} />);
 
         expect(
           chart
             .find(RangeRect)
             .first()
-            .props().style
-        ).to.contain({ fill: "rgb" });
+            .props().style,
+        ).to.contain({ fill: 'rgb' });
       });
     });
   });

--- a/tests/jsdom/spec/ColorHeatmap.spec.js
+++ b/tests/jsdom/spec/ColorHeatmap.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import _ from 'lodash';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { XYPlot, ColorHeatmap, RangeRect } from '../../../src/index.js';
+import { ColorHeatmap, RangeRect } from '../../../src/index.js';
 import { getValue } from '../../../src/utils/Data.js';
 
 describe('ColorHeatmap', () => {
@@ -27,12 +27,10 @@ describe('ColorHeatmap', () => {
     xEnd: d => d.xEnd,
     y: d => d.y,
     yEnd: d => d.yEnd,
-    xScale: d3
-      .scaleLinear()
+    xScale: scaleLinear()
       .domain([-1, 0, 1])
       .range([0, 30]),
-    yScale: d3
-      .scaleLinear()
+    yScale: scaleLinear()
       .domain([0, 10])
       .range([0, 30]),
     colors: ['rebeccapurple', 'goldenrod'],
@@ -42,7 +40,6 @@ describe('ColorHeatmap', () => {
 
   it('renders a color heatmap', () => {
     const chart = mount(<ColorHeatmap {...props} />);
-    const group = chart.find('g');
     const rangeRects = chart.find(RangeRect);
     expect(rangeRects).to.have.length(props.data.length);
   });
@@ -96,10 +93,10 @@ describe('ColorHeatmap', () => {
     describe('when colorScale prop is passed', () => {
       it('sets the color scale to the prop value', () => {
         const propsWithColorScale = { ...props, colorScale: () => 'rgb' };
-        const chart = mount(<ColorHeatmap {...propsWithColorScale} />);
+        const updatedChart = mount(<ColorHeatmap {...propsWithColorScale} />);
 
         expect(
-          chart
+          updatedChart
             .find(RangeRect)
             .first()
             .props().style,

--- a/tests/jsdom/spec/FunnelChart.spec.js
+++ b/tests/jsdom/spec/FunnelChart.spec.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import * as d3 from 'd3';
-import _ from 'lodash';
-import sinon from 'sinon';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
 import { FunnelChart } from '../../../src/index.js';
-import { getValue } from '../../../src/utils/Data.js';
 
 describe('FunnelChart', () => {
   const funnelData = [
@@ -23,12 +20,10 @@ describe('FunnelChart', () => {
     y: d => d.observation,
     pathClassName: 'path-class',
     horizontal: true,
-    xScale: d3
-      .scaleLinear()
+    xScale: scaleLinear()
       .domain([-1, 0, 1])
       .range([0, 30]),
-    yScale: d3
-      .scaleLinear()
+    yScale: scaleLinear()
       .domain([0, 10])
       .range([0, 30]),
     pathStyle: { fill: 'yellow' },

--- a/tests/jsdom/spec/FunnelChart.spec.js
+++ b/tests/jsdom/spec/FunnelChart.spec.js
@@ -1,27 +1,27 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import sinon from "sinon";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { FunnelChart } from "../../../src/index.js";
-import { getValue } from "../../../src/utils/Data.js";
+import { FunnelChart } from '../../../src/index.js';
+import { getValue } from '../../../src/utils/Data.js';
 
-describe("FunnelChart", () => {
+describe('FunnelChart', () => {
   const funnelData = [
     { observation: 1, value: 100 },
     { observation: 2, value: 85 },
     { observation: 3, value: 42 },
     { observation: 4, value: 37 },
-    { observation: 5, value: 12 }
+    { observation: 5, value: 12 },
   ];
 
   const props = {
     data: funnelData,
     x: d => d.value,
     y: d => d.observation,
-    pathClassName: "path-class",
+    pathClassName: 'path-class',
     horizontal: true,
     xScale: d3
       .scaleLinear()
@@ -31,31 +31,31 @@ describe("FunnelChart", () => {
       .scaleLinear()
       .domain([0, 10])
       .range([0, 30]),
-    pathStyle: { fill: "yellow" }
+    pathStyle: { fill: 'yellow' },
   };
 
-  it("renders a funnel chart", () => {
+  it('renders a funnel chart', () => {
     const chart = mount(<FunnelChart {...props} />);
-    const group = chart.find("g.rct-funnel-chart");
+    const group = chart.find('g.rct-funnel-chart');
     expect(group).to.have.length(1);
-    expect(group.find("path")).to.have.length(props.data.length - 1);
+    expect(group.find('path')).to.have.length(props.data.length - 1);
 
-    group.find("path").forEach(path => {
-      const pathD = path.instance().getAttribute("d");
+    group.find('path').forEach(path => {
+      const pathD = path.instance().getAttribute('d');
 
-      expect(pathD).not.to.include("NaN");
+      expect(pathD).not.to.include('NaN');
     });
 
-    const lastPath = group.find("path").last();
-    const pathData = lastPath.instance().getAttribute("d");
-    expect(pathData).to.equal("M1140,12L390,15L-330,15L-1080,12Z");
+    const lastPath = group.find('path').last();
+    const pathData = lastPath.instance().getAttribute('d');
+    expect(pathData).to.equal('M1140,12L390,15L-330,15L-1080,12Z');
   });
 
-  it("passes props correctly", () => {
+  it('passes props correctly', () => {
     const chart = mount(<FunnelChart {...props} />);
-    const lastPath = chart.find("path").last();
+    const lastPath = chart.find('path').last();
     expect(lastPath.props().className).to.include(props.pathClassName);
     expect(lastPath.props().style).to.contain(props.pathStyle);
-    expect(lastPath.props().d).to.be.a("string");
+    expect(lastPath.props().d).to.be.a('string');
   });
 });

--- a/tests/jsdom/spec/Histogram.spec.js
+++ b/tests/jsdom/spec/Histogram.spec.js
@@ -1,14 +1,14 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import { mount, shallow } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { testWithScales, expectProps } from "../utils";
-import { XYPlot, Histogram, AreaBarChart } from "../../../src/index.js";
+import { expectProps } from '../utils';
+import { Histogram, AreaBarChart } from '../../../src/index.js';
 
-describe("Histogram", () => {
-  it("it passes most props through to AreaBarChart", () => {
+describe('Histogram', () => {
+  it('it passes most props through to AreaBarChart', () => {
     // histogram is a wrapper around AreaBarChart
     const props = {
       xScale: d3
@@ -25,11 +25,11 @@ describe("Histogram", () => {
       },
       thresholds: 3,
       nice: true,
-      barClassName: "test-bar-class-name",
-      barStyle: { fill: "red" },
-      onMouseEnterBar: () => "onMouseEnterBar",
-      onMouseMoveBar: () => "onMouseMoveBar",
-      onMouseLeaveBar: () => "onMouseLeaveBar"
+      barClassName: 'test-bar-class-name',
+      barStyle: { fill: 'red' },
+      onMouseEnterBar: () => 'onMouseEnterBar',
+      onMouseMoveBar: () => 'onMouseMoveBar',
+      onMouseLeaveBar: () => 'onMouseLeaveBar',
     };
 
     const histogram = mount(<Histogram {...props} />);
@@ -40,17 +40,19 @@ describe("Histogram", () => {
       data: Histogram.computeHistogram(
         props.data,
         props.thresholds,
-        props.value
-      )
+        props.value,
+        null,
+        props.nice,
+      ),
     };
 
     // Omit data since expectProps will check for reference equality on the data instead of
-    expectProps(areaBarChart, _.omit(parsedProps, ["data"]));
+    expectProps(areaBarChart, _.omit(parsedProps, ['data']));
     // Check value of data prop is equal
     expect(areaBarChart.props().data).to.eql(parsedProps.data);
   });
 
-  it("renders histogram", () => {
+  it('renders histogram', () => {
     // histogram is a wrapper around AreaBarChart
     const props = {
       xScale: d3
@@ -67,16 +69,16 @@ describe("Histogram", () => {
       },
       nice: true,
       thresholds: 3,
-      barClassName: "test-bar-class-name",
-      barStyle: { fill: "red" },
-      onMouseEnterBar: () => "onMouseEnterBar",
-      onMouseMoveBar: () => "onMouseMoveBar",
-      onMouseLeaveBar: () => "onMouseLeaveBar"
+      barClassName: 'test-bar-class-name',
+      barStyle: { fill: 'red' },
+      onMouseEnterBar: () => 'onMouseEnterBar',
+      onMouseMoveBar: () => 'onMouseMoveBar',
+      onMouseLeaveBar: () => 'onMouseLeaveBar',
     };
 
     const histogram = mount(<Histogram {...props} />);
-    const group = histogram.find("g");
-    const bars = group.find("rect");
+    const group = histogram.find('g');
+    const bars = group.find('rect');
 
     // histogram creates 4 bars
     expect(bars).to.have.length(4);

--- a/tests/jsdom/spec/Histogram.spec.js
+++ b/tests/jsdom/spec/Histogram.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import _ from 'lodash';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
@@ -11,12 +11,10 @@ describe('Histogram', () => {
   it('it passes most props through to AreaBarChart', () => {
     // histogram is a wrapper around AreaBarChart
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([-1, 0, 1])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 10])
         .range([100, 0]),
       data: [-1, 0, 1, -1, 0, 1, 1, 1],
@@ -55,12 +53,10 @@ describe('Histogram', () => {
   it('renders histogram', () => {
     // histogram is a wrapper around AreaBarChart
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([-1, 0, 1])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 10])
         .range([100, 0]),
       data: [-1, 0, 1, -1, 0, 1, 1, 1],

--- a/tests/jsdom/spec/LineChart.spec.js
+++ b/tests/jsdom/spec/LineChart.spec.js
@@ -1,29 +1,16 @@
 import { expect } from 'chai';
-import * as d3 from 'd3';
+import { scaleLinear, scaleTime, scalePoint } from 'd3-scale';
 import { mount } from 'enzyme';
 import React from 'react';
 import { LineChart, XYPlot } from '../../../src/index.js';
 
-const getXYArrayValue = {
-  // accessors for (X, Y) data from simple arrays that look like [[x, y], [x, y]]
-  x: d => d[0],
-  y: d => d[1],
-};
-
 describe('LineChart', () => {
-  const linearYScale = d3
-    .scaleLinear()
-    .domain([0, 1])
-    .range([100, 0]);
-
   it('passes props correctly to group and path elements', () => {
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([0, 2])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [[0, 0.5], [1, 1], [2, 0.25]],
@@ -43,12 +30,10 @@ describe('LineChart', () => {
   it('renders a line with number X & Y scales', () => {
     // make simple number-number line chart with 3 datapoints
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([0, 2])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [[0, 0.5], [1, 1], [2, 0.25]],
@@ -66,15 +51,13 @@ describe('LineChart', () => {
   it('renders a line with time X scale and number Y scale', () => {
     // make simple number-time line chart with 3 datapoints
     const props = {
-      xScale: d3
-        .scaleTime()
+      xScale: scaleTime()
         .range([0, 100])
         .domain([
           new Date('2015-01-01T00:00:00.000Z'),
           new Date('2015-01-03T00:00:00.000Z'),
         ]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [
@@ -96,12 +79,10 @@ describe('LineChart', () => {
   it('renders a line with ordinal X scale and number Y scale', () => {
     // make simple number-time line chart with 3 datapoints
     const props = {
-      xScale: d3
-        .scalePoint()
+      xScale: scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [['a', 0.5], ['b', 1], ['c', 0.25]],

--- a/tests/jsdom/spec/LineChart.spec.js
+++ b/tests/jsdom/spec/LineChart.spec.js
@@ -1,22 +1,22 @@
-import { expect } from "chai";
-import * as d3 from "d3";
-import { mount } from "enzyme";
-import React from "react";
-import { LineChart, XYPlot } from "../../../src/index.js";
+import { expect } from 'chai';
+import * as d3 from 'd3';
+import { mount } from 'enzyme';
+import React from 'react';
+import { LineChart, XYPlot } from '../../../src/index.js';
 
 const getXYArrayValue = {
   // accessors for (X, Y) data from simple arrays that look like [[x, y], [x, y]]
   x: d => d[0],
-  y: d => d[1]
+  y: d => d[1],
 };
 
-describe("LineChart", () => {
+describe('LineChart', () => {
   const linearYScale = d3
     .scaleLinear()
     .domain([0, 1])
     .range([100, 0]);
 
-  it("passes props correctly to group and path elements", () => {
+  it('passes props correctly to group and path elements', () => {
     const props = {
       xScale: d3
         .scaleLinear()
@@ -29,18 +29,18 @@ describe("LineChart", () => {
       data: [[0, 0.5], [1, 1], [2, 0.25]],
       x: d => d[0],
       y: d => d[1],
-      lineClassName: "my-line",
-      lineStyle: { fill: "blue" }
+      lineClassName: 'my-line',
+      lineStyle: { fill: 'blue' },
     };
     const chart = mount(<LineChart {...props} />);
-    const group = chart.find("g");
-    const path = chart.find("path");
+    const group = chart.find('g');
+    const path = chart.find('path');
 
     expect(path.props().style).to.equal(props.lineStyle);
     expect(group.props().className).to.contain(props.lineClassName);
   });
 
-  it("renders a line with number X & Y scales", () => {
+  it('renders a line with number X & Y scales', () => {
     // make simple number-number line chart with 3 datapoints
     const props = {
       xScale: d3
@@ -53,86 +53,86 @@ describe("LineChart", () => {
         .range([100, 0]),
       data: [[0, 0.5], [1, 1], [2, 0.25]],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
 
     // ensure line is drawn as expected
     const chart = mount(<LineChart {...props} />);
-    const path = chart.find("path");
-    const pathData = path.instance().getAttribute("d");
-    expect(pathData).to.equal("M0,50L50,0L100,75");
+    const path = chart.find('path');
+    const pathData = path.instance().getAttribute('d');
+    expect(pathData).to.equal('M0,50L50,0L100,75');
   });
 
-  it("renders a line with time X scale and number Y scale", () => {
+  it('renders a line with time X scale and number Y scale', () => {
     // make simple number-time line chart with 3 datapoints
     const props = {
       xScale: d3
         .scaleTime()
         .range([0, 100])
         .domain([
-          new Date("2015-01-01T00:00:00.000Z"),
-          new Date("2015-01-03T00:00:00.000Z")
+          new Date('2015-01-01T00:00:00.000Z'),
+          new Date('2015-01-03T00:00:00.000Z'),
         ]),
       yScale: d3
         .scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
       data: [
-        [new Date("2015-01-01T00:00:00.000Z"), 0.5],
-        [new Date("2015-01-02T00:00:00.000Z"), 1],
-        [new Date("2015-01-03T00:00:00.000Z"), 0.25]
+        [new Date('2015-01-01T00:00:00.000Z'), 0.5],
+        [new Date('2015-01-02T00:00:00.000Z'), 1],
+        [new Date('2015-01-03T00:00:00.000Z'), 0.25],
       ],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
 
     // ensure line is drawn as expected
     const chart = mount(<LineChart {...props} />);
-    const path = chart.find("path");
-    const pathData = path.instance().getAttribute("d");
-    expect(pathData).to.equal("M0,50L50,0L100,75");
+    const path = chart.find('path');
+    const pathData = path.instance().getAttribute('d');
+    expect(pathData).to.equal('M0,50L50,0L100,75');
   });
 
-  it("renders a line with ordinal X scale and number Y scale", () => {
+  it('renders a line with ordinal X scale and number Y scale', () => {
     // make simple number-time line chart with 3 datapoints
     const props = {
       xScale: d3
         .scalePoint()
-        .domain(["a", "b", "c"])
+        .domain(['a', 'b', 'c'])
         .range([0, 100]),
       yScale: d3
         .scaleLinear()
         .domain([0, 1])
         .range([100, 0]),
-      data: [["a", 0.5], ["b", 1], ["c", 0.25]],
+      data: [['a', 0.5], ['b', 1], ['c', 0.25]],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
 
     // ensure line is drawn as expected
     const chart = mount(<LineChart {...props} />);
-    const path = chart.find("path");
-    const pathData = path.instance().getAttribute("d");
-    expect(pathData).to.equal("M0,50L50,0L100,75");
+    const path = chart.find('path');
+    const pathData = path.instance().getAttribute('d');
+    expect(pathData).to.equal('M0,50L50,0L100,75');
   });
 
-  it("renders a line chart within an XYPlot", () => {
+  it('renders a line chart within an XYPlot', () => {
     const xyProps = { width: 100, height: 100 };
     const lineProps = {
       data: [[0, 0.5], [1, 1], [2, 0.25]],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
 
     const chart = mount(
       <XYPlot {...xyProps}>
         <LineChart {...lineProps} />
-      </XYPlot>
+      </XYPlot>,
     );
 
-    const path = chart.find("path");
+    const path = chart.find('path');
     expect(path).to.have.length(1);
-    const pathData = path.instance().getAttribute("d");
-    expect(pathData).not.to.include("NaN");
+    const pathData = path.instance().getAttribute('d');
+    expect(pathData).not.to.include('NaN');
   });
 });

--- a/tests/jsdom/spec/MarkerLineChart.spec.js
+++ b/tests/jsdom/spec/MarkerLineChart.spec.js
@@ -1,29 +1,29 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import sinon from "sinon";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { MarkerLineChart } from "../../../src/index.js";
+import { MarkerLineChart } from '../../../src/index.js';
 
-describe("MarkerLineChart", () => {
+describe('MarkerLineChart', () => {
   const props = {
     xScale: d3.scaleLinear().domain([0, 30]),
     yScale: d3.scaleLinear().domain([0, 1]),
     data: _.range(30),
     x: d => d,
     y: d => d + 5,
-    lineClassName: "my-line",
-    lineStyle: { fill: "blue" },
+    lineClassName: 'my-line',
+    lineStyle: { fill: 'blue' },
     onMouseEnterLine: sinon.spy(),
     onMouseMoveLine: sinon.spy(),
-    onMouseLeaveLine: sinon.spy()
+    onMouseLeaveLine: sinon.spy(),
   };
 
-  it("passes props correctly to line elements", () => {
+  it('passes props correctly to line elements', () => {
     let chart = mount(<MarkerLineChart {...props} />);
-    let lines = chart.find("line");
+    let lines = chart.find('line');
 
     lines.forEach(line => {
       expect(line.props().className).to.contain(props.lineClassName);
@@ -32,7 +32,7 @@ describe("MarkerLineChart", () => {
 
     // test with xEnd and yEnd
     chart = mount(<MarkerLineChart {...props} xEnd={d => d + 10} />);
-    lines = chart.find("line");
+    lines = chart.find('line');
 
     lines.forEach(line => {
       expect(line.props().className).to.contain(props.lineClassName);
@@ -40,10 +40,8 @@ describe("MarkerLineChart", () => {
     });
 
     // test with xEnd and yEnd
-    chart = mount(
-      <MarkerLineChart {...props} horizontal yEnd={d => d + 10} />
-    );
-    lines = chart.find("line");
+    chart = mount(<MarkerLineChart {...props} horizontal yEnd={d => d + 10} />);
+    lines = chart.find('line');
 
     lines.forEach(line => {
       expect(line.props().className).to.contain(props.lineClassName);
@@ -51,10 +49,10 @@ describe("MarkerLineChart", () => {
     });
   });
 
-  it("renders the correct amount of group and line elements and has proper width/height", () => {
+  it('renders the correct amount of group and line elements and has proper width/height', () => {
     let chart = mount(<MarkerLineChart {...props} />);
-    let lines = chart.find("line");
-    const group = chart.find("g");
+    let lines = chart.find('line');
+    const group = chart.find('g');
 
     expect(group).to.have.lengthOf(1);
     expect(lines).to.have.lengthOf(props.data.length);
@@ -65,12 +63,12 @@ describe("MarkerLineChart", () => {
     // test with xEnd and yEnd
     const xEnd = d => d + 10;
     chart = mount(<MarkerLineChart {...props} xEnd={xEnd} />);
-    lines = chart.find("line");
+    lines = chart.find('line');
 
     lines.forEach((line, idx) => {
       const d = props.data[idx];
       const difference = Math.abs(
-        props.xScale(props.x(d)) - props.xScale(xEnd(d))
+        props.xScale(props.x(d)) - props.xScale(xEnd(d)),
       );
 
       expect(Math.abs(line.props().x2 - line.props().x1)).to.equal(difference);
@@ -78,30 +76,30 @@ describe("MarkerLineChart", () => {
 
     const yEnd = d => d + 10;
     chart = mount(<MarkerLineChart {...props} horizontal yEnd={yEnd} />);
-    lines = chart.find("line");
+    lines = chart.find('line');
 
     lines.forEach((line, idx) => {
       const d = props.data[idx];
       const difference = Math.abs(
-        props.yScale(props.y(d)) - props.yScale(yEnd(d))
+        props.yScale(props.y(d)) - props.yScale(yEnd(d)),
       );
 
       expect(Math.abs(line.props().y2 - line.props().y1)).to.equal(difference);
     });
   });
 
-  it("triggers event handlers", () => {
+  it('triggers event handlers', () => {
     const chart = mount(<MarkerLineChart {...props} />);
-    const line = chart.find("line").first();
+    const line = chart.find('line').first();
 
     expect(props.onMouseMoveLine).not.to.have.been.called;
-    line.simulate("mousemove");
+    line.simulate('mousemove');
     expect(props.onMouseMoveLine).to.have.been.called;
     expect(props.onMouseEnterLine).not.to.have.been.called;
-    line.simulate("mouseenter");
+    line.simulate('mouseenter');
     expect(props.onMouseEnterLine).to.have.been.called;
     expect(props.onMouseLeaveLine).not.to.have.been.called;
-    line.simulate("mouseleave");
+    line.simulate('mouseleave');
     expect(props.onMouseLeaveLine).to.have.been.called;
   });
 });

--- a/tests/jsdom/spec/MarkerLineChart.spec.js
+++ b/tests/jsdom/spec/MarkerLineChart.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import _ from 'lodash';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -9,8 +9,8 @@ import { MarkerLineChart } from '../../../src/index.js';
 
 describe('MarkerLineChart', () => {
   const props = {
-    xScale: d3.scaleLinear().domain([0, 30]),
-    yScale: d3.scaleLinear().domain([0, 1]),
+    xScale: scaleLinear().domain([0, 30]),
+    yScale: scaleLinear().domain([0, 1]),
     data: _.range(30),
     x: d => d,
     y: d => d + 5,

--- a/tests/jsdom/spec/RangeBarChart.spec.js
+++ b/tests/jsdom/spec/RangeBarChart.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint } from 'd3-scale';
 import { mount } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -7,12 +7,10 @@ import { Bar, RangeBarChart } from '../../../src/index.js';
 
 describe('RangeBarChart', () => {
   const props = {
-    xScale: d3
-      .scalePoint()
+    xScale: scalePoint()
       .domain(['a', 'b', 'c'])
       .range([0, 100]),
-    yScale: d3
-      .scaleLinear()
+    yScale: scaleLinear()
       .domain([0, 1])
       .range([100, 0]),
     data: [['a', [0.3, 0.5]], ['b', [0.6, 0.9]]],

--- a/tests/jsdom/spec/RangeRect.spec.js
+++ b/tests/jsdom/spec/RangeRect.spec.js
@@ -1,23 +1,23 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import chai from "chai";
-import { mount, shallow } from "enzyme";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import chai from 'chai';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 const { expect } = chai;
 
-import { testWithScales } from "../utils";
-import { RangeRect } from "../../../src/index.js";
+import { testWithScales } from '../utils';
+import { RangeRect } from '../../../src/index.js';
 
-describe("RangeRect", () => {
-  it("renders a RangeRect with correct placement and size", () => {
+describe('RangeRect', () => {
+  it('renders a RangeRect with correct placement and size', () => {
     testWithScales(
-      ["linear", "ordinal"],
+      ['linear', 'ordinal'],
       ({ scale: xScale, testValues: xTestValues }) => {
         testWithScales(
-          ["linear", "ordinal"],
+          ['linear', 'ordinal'],
           ({ scale: yScale, testValues: yTestValues }) => {
             [0, 1].forEach(i => {
               const el = mount(
@@ -28,12 +28,12 @@ describe("RangeRect", () => {
                     x: xTestValues[i],
                     y: yTestValues[i],
                     xEnd: xTestValues[i + 1],
-                    yEnd: yTestValues[i + 1]
+                    yEnd: yTestValues[i + 1],
                   }}
-                />
+                />,
               );
 
-              const rect = el.find("rect");
+              const rect = el.find('rect');
               expect(rect).to.have.length(1);
               const rectProps = rect.props();
 
@@ -41,28 +41,28 @@ describe("RangeRect", () => {
               const xEndPosition = xScale(xTestValues[i + 1]);
               expect(rectProps.x).to.equal(Math.min(xPosition, xEndPosition));
               expect(rectProps.width).to.equal(
-                Math.abs(xEndPosition - xPosition)
+                Math.abs(xEndPosition - xPosition),
               );
 
               const yPosition = yScale(yTestValues[i]);
               const yEndPosition = yScale(yTestValues[i + 1]);
               expect(rectProps.y).to.equal(Math.min(yPosition, yEndPosition));
               expect(rectProps.height).to.equal(
-                Math.abs(yEndPosition - yPosition)
+                Math.abs(yEndPosition - yPosition),
               );
             });
-          }
+          },
         );
-      }
+      },
     );
   });
 
-  it("attaches style, className and mouse event handler props", () => {
+  it('attaches style, className and mouse event handler props', () => {
     testWithScales(
-      ["linear", "ordinal"],
+      ['linear', 'ordinal'],
       ({ scale: xScale, testValues: xTestValues }) => {
         testWithScales(
-          ["linear", "ordinal"],
+          ['linear', 'ordinal'],
           ({ scale: yScale, testValues: yTestValues }) => {
             const props = {
               xScale,
@@ -71,15 +71,15 @@ describe("RangeRect", () => {
               y: yTestValues[0],
               xEnd: xTestValues[1],
               yEnd: yTestValues[1],
-              style: { fill: "red", stroke: "blue" },
-              className: "my-test-rect",
+              style: { fill: 'red', stroke: 'blue' },
+              className: 'my-test-rect',
               onMouseEnter: sinon.spy(),
               onMouseMove: sinon.spy(),
-              onMouseLeave: sinon.spy()
+              onMouseLeave: sinon.spy(),
             };
 
             const el = mount(<RangeRect {...props} />);
-            const rect = el.find("rect");
+            const rect = el.find('rect');
             expect(rect).to.have.length(1);
             const rectProps = rect.props();
 
@@ -87,19 +87,19 @@ describe("RangeRect", () => {
             expect(rectProps.className).to.include(props.className);
 
             expect(rectProps.onMouseEnter).not.to.have.been.called;
-            rect.simulate("mouseenter");
+            rect.simulate('mouseenter');
             expect(rectProps.onMouseEnter).to.have.been.calledOnce;
 
             expect(rectProps.onMouseMove).not.to.have.been.called;
-            rect.simulate("mousemove");
+            rect.simulate('mousemove');
             expect(rectProps.onMouseMove).to.have.been.calledOnce;
 
             expect(rectProps.onMouseLeave).not.to.have.been.called;
-            rect.simulate("mouseleave");
+            rect.simulate('mouseleave');
             expect(rectProps.onMouseLeave).to.have.been.calledOnce;
-          }
+          },
         );
-      }
+      },
     );
   });
 });

--- a/tests/jsdom/spec/RangeRect.spec.js
+++ b/tests/jsdom/spec/RangeRect.spec.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import * as d3 from 'd3';
-import _ from 'lodash';
 import chai from 'chai';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 chai.use(sinonChai);

--- a/tests/jsdom/spec/ScatterPlot.spec.js
+++ b/tests/jsdom/spec/ScatterPlot.spec.js
@@ -1,50 +1,50 @@
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
-import sinon from "sinon";
-import { mount } from "enzyme";
-import { ScatterPlot } from "../../../src/index.js";
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { ScatterPlot } from '../../../src/index.js';
 
-describe("ScatterPlot", () => {
+describe('ScatterPlot', () => {
   const props = {
     data: [[0, 0], [2, 1], [5, 1], [3, 5], [4, 2], [5, 5], [1, 4]],
     x: d => d[0],
     y: d => d[1],
-    pointClassName: "my-point",
-    pointStyle: { fill: "blue" },
+    pointClassName: 'my-point',
+    pointStyle: { fill: 'blue' },
     xScale: d3.scaleLinear().domain([0, 5]),
     yScale: d3.scaleLinear().domain([0, 5]),
     onMouseEnterPoint: sinon.spy(),
     onMouseMovePoint: sinon.spy(),
     onMouseLeavePoint: sinon.spy(),
-    pointOffset: [2, 2]
+    pointOffset: [2, 2],
   };
 
-  it("passes props correctly to points", () => {
+  it('passes props correctly to points', () => {
     let chart = mount(<ScatterPlot {...props} />);
-    let points = chart.find("circle");
+    let points = chart.find('circle');
 
     points.forEach(point => {
       expect(point.props().className).to.contain(props.pointClassName);
       expect(point.props().style).to.eql(props.pointStyle);
     });
 
-    chart = mount(<ScatterPlot {...props} pointSymbol={d => "a"} />);
-    points = chart.find("text");
+    chart = mount(<ScatterPlot {...props} pointSymbol={d => 'a'} />);
+    points = chart.find('text');
 
     points.forEach(point => {
       expect(point.props().className).to.contain(props.pointClassName);
       expect(point.props().style).to.eql({
-        textAnchor: "middle",
-        dominantBaseline: "central",
-        ...props.pointStyle
+        textAnchor: 'middle',
+        dominantBaseline: 'central',
+        ...props.pointStyle,
       });
     });
   });
 
-  it("renders correct amount of points in correct area", () => {
+  it('renders correct amount of points in correct area', () => {
     const chart = mount(<ScatterPlot {...props} />);
-    const points = chart.find("circle");
+    const points = chart.find('circle');
 
     expect(points).to.have.lengthOf(props.data.length);
 
@@ -58,18 +58,18 @@ describe("ScatterPlot", () => {
     });
   });
 
-  it("triggers event handlers", () => {
+  it('triggers event handlers', () => {
     const chart = mount(<ScatterPlot {...props} />);
-    const points = chart.find("circle");
+    const points = chart.find('circle');
 
     expect(props.onMouseMovePoint).not.to.have.been.called;
-    points.at(1).simulate("mousemove");
+    points.at(1).simulate('mousemove');
     expect(props.onMouseMovePoint).to.have.been.called;
     expect(props.onMouseEnterPoint).not.to.have.been.called;
-    points.at(1).simulate("mouseenter");
+    points.at(1).simulate('mouseenter');
     expect(props.onMouseEnterPoint).to.have.been.called;
     expect(props.onMouseLeavePoint).not.to.have.been.called;
-    points.at(1).simulate("mouseleave");
+    points.at(1).simulate('mouseleave');
     expect(props.onMouseLeavePoint).to.have.been.called;
   });
 });

--- a/tests/jsdom/spec/ScatterPlot.spec.js
+++ b/tests/jsdom/spec/ScatterPlot.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
@@ -12,8 +12,8 @@ describe('ScatterPlot', () => {
     y: d => d[1],
     pointClassName: 'my-point',
     pointStyle: { fill: 'blue' },
-    xScale: d3.scaleLinear().domain([0, 5]),
-    yScale: d3.scaleLinear().domain([0, 5]),
+    xScale: scaleLinear().domain([0, 5]),
+    yScale: scaleLinear().domain([0, 5]),
     onMouseEnterPoint: sinon.spy(),
     onMouseMovePoint: sinon.spy(),
     onMouseLeavePoint: sinon.spy(),
@@ -29,7 +29,7 @@ describe('ScatterPlot', () => {
       expect(point.props().style).to.eql(props.pointStyle);
     });
 
-    chart = mount(<ScatterPlot {...props} pointSymbol={d => 'a'} />);
+    chart = mount(<ScatterPlot {...props} pointSymbol={() => 'a'} />);
     points = chart.find('text');
 
     points.forEach(point => {

--- a/tests/jsdom/spec/XGrid.spec.js
+++ b/tests/jsdom/spec/XGrid.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
-import _ from 'lodash';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
@@ -16,7 +15,7 @@ describe('XGrid', () => {
     spacingRight: 10,
     lineClassName: 'xgrid-line-class',
     lineStyle: { stroke: 'blue' },
-    xScale: d3.scaleLinear().domain([0, 100]),
+    xScale: scaleLinear().domain([0, 100]),
   };
 
   it('passes props correctly to XLine', () => {

--- a/tests/jsdom/spec/XGrid.spec.js
+++ b/tests/jsdom/spec/XGrid.spec.js
@@ -1,31 +1,31 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { XGrid, XLine } from "../../../src/index.js";
-import { getScaleTicks, getTickDomain } from "../../../src/utils/Scale";
+import { XGrid, XLine } from '../../../src/index.js';
+import { getScaleTicks, getTickDomain } from '../../../src/utils/Scale';
 
-describe("XGrid", () => {
+describe('XGrid', () => {
   const props = {
     height: 10,
     spacingTop: 10,
     spacingBottom: 10,
     spacingLeft: 10,
     spacingRight: 10,
-    lineClassName: "xgrid-line-class",
-    lineStyle: { stroke: "blue" },
-    xScale: d3.scaleLinear().domain([0, 100])
+    lineClassName: 'xgrid-line-class',
+    lineStyle: { stroke: 'blue' },
+    xScale: d3.scaleLinear().domain([0, 100]),
   };
 
-  it("passes props correctly to XLine", () => {
+  it('passes props correctly to XLine', () => {
     const xGrid = mount(<XGrid {...props} />);
     const xLines = xGrid.find(XLine);
-    const group = xGrid.find("g");
+    const group = xGrid.find('g');
 
     expect(group).to.have.lengthOf(1);
-    expect(group.getDOMNode().className).to.equal("rct-chart-grid-x");
+    expect(group.getDOMNode().className).to.equal('rct-chart-grid-x');
 
     xLines.forEach(xLine => {
       const xLineProps = xLine.props();
@@ -41,13 +41,13 @@ describe("XGrid", () => {
     });
   });
 
-  it("renders the correct amount of XLines given tickCount", () => {
+  it('renders the correct amount of XLines given tickCount', () => {
     const tickCount = 50;
     const xGrid = mount(<XGrid {...props} tickCount={tickCount} />);
-    const group = xGrid.find("g");
+    const group = xGrid.find('g');
 
     expect(group).to.have.lengthOf(1);
-    expect(group.getDOMNode().className).to.equal("rct-chart-grid-x");
+    expect(group.getDOMNode().className).to.equal('rct-chart-grid-x');
 
     const xLines = xGrid.find(XLine);
     const numTicksMade = getScaleTicks(props.xScale, null, tickCount);
@@ -55,25 +55,25 @@ describe("XGrid", () => {
     expect(xLines).to.have.lengthOf(numTicksMade.length);
   });
 
-  it("renders the correct amount of XLines given ticks", () => {
+  it('renders the correct amount of XLines given ticks', () => {
     const ticks = [0, 25, 50, 100];
     const xGrid = mount(<XGrid {...props} ticks={ticks} />);
-    const group = xGrid.find("g");
+    const group = xGrid.find('g');
 
     expect(group).to.have.lengthOf(1);
-    expect(group.getDOMNode().className).to.equal("rct-chart-grid-x");
+    expect(group.getDOMNode().className).to.equal('rct-chart-grid-x');
 
     const xLines = xGrid.find(XLine);
     expect(xLines).to.have.lengthOf(ticks.length);
   });
 
-  it("getTickDomain works as expected", () => {
+  it('getTickDomain works as expected', () => {
     const ticks = [0, 25, 50, 100];
 
     const result = getTickDomain(props.xScale, { ...props, ticks });
 
     expect(XGrid.getTickDomain({ ...props, ticks })).to.eql({
-      xTickDomain: result
+      xTickDomain: result,
     });
   });
 });

--- a/tests/jsdom/spec/XLine.spec.js
+++ b/tests/jsdom/spec/XLine.spec.js
@@ -1,33 +1,33 @@
-import * as d3 from "d3";
-import React from "react";
-import { shallow } from "enzyme";
-import chaiEnzyme from "chai-enzyme";
-import chai from "chai";
+import * as d3 from 'd3';
+import React from 'react';
+import { shallow } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai from 'chai';
 chai.use(chaiEnzyme());
 const { expect } = chai;
 
-import XLine from "../../../src/XLine";
+import XLine from '../../../src/XLine';
 
 function findLine(wrapper) {
-  return wrapper.find("line.rct-chart-line-x").first();
+  return wrapper.find('line.rct-chart-line-x').first();
 }
 
 function expectCorrectLinePlacement(wrapper, value, scale) {
-  const lines = wrapper.find("line.rct-chart-line-x");
+  const lines = wrapper.find('line.rct-chart-line-x');
   expect(lines).to.have.length(1);
   const line = lines.first();
-  expect(line.first().prop("x1")).to.equal(scale(value));
-  expect(line.first().prop("x2")).to.equal(scale(value));
+  expect(line.first().prop('x1')).to.equal(scale(value));
+  expect(line.first().prop('x2')).to.equal(scale(value));
   return wrapper;
 }
 
 function getLineHeight(line) {
-  const y1 = +line.prop("y1") || 0;
-  const y2 = +line.prop("y2");
+  const y1 = +line.prop('y1') || 0;
+  const y2 = +line.prop('y2');
   return Math.abs(y2 - y1);
 }
 
-describe("XLine", () => {
+describe('XLine', () => {
   const linearScale = d3
     .scaleLinear()
     .domain([-5, 5])
@@ -38,39 +38,39 @@ describe("XLine", () => {
     .range([0, 500]);
   const ordinalScale = d3
     .scalePoint()
-    .domain(["a", "b", "c", "d"])
+    .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 
   const linearValue = 2;
   const timeValue = new Date(2009, 9, 19);
-  const ordinalValue = "c";
+  const ordinalValue = 'c';
   const commonProps = { spacing: { top: 0, bottom: 0, left: 0, right: 0 } };
 
-  it("renders a .rct-chart-line-x element in the correct place", () => {
+  it('renders a .rct-chart-line-x element in the correct place', () => {
     let wrapper = shallow(
-      <XLine xScale={linearScale} value={linearValue} {...commonProps} />
+      <XLine xScale={linearScale} value={linearValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, linearValue, linearScale);
 
     wrapper = shallow(
-      <XLine xScale={timeScale} value={timeValue} {...commonProps} />
+      <XLine xScale={timeScale} value={timeValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, timeValue, timeScale);
 
     wrapper = shallow(
-      <XLine xScale={ordinalScale} value={ordinalValue} {...commonProps} />
+      <XLine xScale={ordinalScale} value={ordinalValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, ordinalValue, ordinalScale);
   });
 
-  it("renders a line with the correct height", () => {
+  it('renders a line with the correct height', () => {
     let wrapper = shallow(
       <XLine
         xScale={linearScale}
         value={linearValue}
         height={200}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineHeight(findLine(wrapper))).to.equal(200);
 
@@ -80,34 +80,34 @@ describe("XLine", () => {
         value={linearValue}
         height={400}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineHeight(findLine(wrapper))).to.equal(400);
   });
 
-  it("passes className to the line", () => {
+  it('passes className to the line', () => {
     const wrapper = shallow(
       <XLine
         xScale={linearScale}
         value={linearValue}
-        className={"test-line-class"}
+        className="test-line-class"
         {...commonProps}
-      />
+      />,
     );
-    expect(wrapper).to.have.descendants("line.test-line-class");
+    expect(wrapper).to.have.descendants('line.test-line-class');
   });
 
-  it("passes style to the line", () => {
-    const style = { fill: "red" };
+  it('passes style to the line', () => {
+    const style = { fill: 'red' };
     const wrapper = shallow(
       <XLine
         xScale={linearScale}
         value={linearValue}
         style={style}
         {...commonProps}
-      />
+      />,
     );
-    expect(findLine(wrapper).prop("style")).to.deep.equal(style);
+    expect(findLine(wrapper).prop('style')).to.deep.equal(style);
   });
 
   it("limits the line's height using yLimit", () => {
@@ -120,7 +120,7 @@ describe("XLine", () => {
         value={linearValue}
         yLimit={limit}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineHeight(findLine(wrapper))).to.equal(linearScale(limit));
   });

--- a/tests/jsdom/spec/XLine.spec.js
+++ b/tests/jsdom/spec/XLine.spec.js
@@ -1,4 +1,4 @@
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint, scaleTime } from 'd3-scale';
 import React from 'react';
 import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
@@ -28,16 +28,13 @@ function getLineHeight(line) {
 }
 
 describe('XLine', () => {
-  const linearScale = d3
-    .scaleLinear()
+  const linearScale = scaleLinear()
     .domain([-5, 5])
     .range([0, 500]);
-  const timeScale = d3
-    .scaleTime()
+  const timeScale = scaleTime()
     .domain([new Date(2009, 0, 1), new Date(2010, 0, 1)])
     .range([0, 500]);
-  const ordinalScale = d3
-    .scalePoint()
+  const ordinalScale = scalePoint()
     .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 

--- a/tests/jsdom/spec/XTicks.spec.js
+++ b/tests/jsdom/spec/XTicks.spec.js
@@ -1,37 +1,37 @@
-import _ from "lodash";
-import * as d3 from "d3";
-import React from "react";
-import { shallow, mount } from "enzyme";
-import chaiEnzyme from "chai-enzyme";
-import chai from "chai";
+import _ from 'lodash';
+import * as d3 from 'd3';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai from 'chai';
 chai.use(chaiEnzyme());
 const { expect } = chai;
 
-import XTicks from "../../../src/XTicks";
+import XTicks from '../../../src/XTicks';
 
 function expectTicksToExist(wrapper) {
-  const ticksGroup = wrapper.find("g.rct-chart-ticks-x");
+  const ticksGroup = wrapper.find('g.rct-chart-ticks-x');
   expect(ticksGroup).to.have.length(1);
-  expect(ticksGroup).to.have.descendants("line.rct-chart-tick-x");
+  expect(ticksGroup).to.have.descendants('line.rct-chart-tick-x');
   return wrapper;
 }
 
 function expectCorrectTickPlacement(wrapper, ticks, scale) {
-  const tickLines = wrapper.find("line.rct-chart-tick-x");
+  const tickLines = wrapper.find('line.rct-chart-tick-x');
   expect(tickLines).to.have.length(ticks.length);
   tickLines.forEach((line, i) => {
-    expect(Math.round(+line.prop("x1"))).to.equal(Math.round(scale(ticks[i])));
+    expect(Math.round(+line.prop('x1'))).to.equal(Math.round(scale(ticks[i])));
   });
   return wrapper;
 }
 
 function getLineHeight(line) {
-  const y1 = +line.prop("y1") || 0;
-  const y2 = +line.prop("y2");
+  const y1 = +line.prop('y1') || 0;
+  const y2 = +line.prop('y2');
   return Math.abs(y2 - y1);
 }
 
-describe("XTicks", () => {
+describe('XTicks', () => {
   const linearScale = d3
     .scaleLinear()
     .domain([-5, 5])
@@ -42,164 +42,164 @@ describe("XTicks", () => {
     .range([0, 500]);
   const ordinalScale = d3
     .scalePoint()
-    .domain(["a", "b", "c", "d"])
+    .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 
-  it("renders a .rct-chart-ticks-x element with tick lines", () => {
+  it('renders a .rct-chart-ticks-x element with tick lines', () => {
     expectTicksToExist(shallow(<XTicks xScale={linearScale} />));
     expectTicksToExist(shallow(<XTicks xScale={ordinalScale} />));
     expectTicksToExist(shallow(<XTicks xScale={timeScale} />));
   });
 
-  it("uses `tickCount` to determine approx. # of ticks to display on number/time scales", () => {
+  it('uses `tickCount` to determine approx. # of ticks to display on number/time scales', () => {
     let wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickCount={11} />)
+      shallow(<XTicks xScale={linearScale} tickCount={11} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-x")).to.have.length(11);
+    expect(wrapper.find('line.rct-chart-tick-x')).to.have.length(11);
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickCount={3} />)
+      shallow(<XTicks xScale={linearScale} tickCount={3} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-x")).to.have.length(3);
+    expect(wrapper.find('line.rct-chart-tick-x')).to.have.length(3);
 
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={timeScale} tickCount={13} />)
+      shallow(<XTicks xScale={timeScale} tickCount={13} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-x")).to.have.length(13);
+    expect(wrapper.find('line.rct-chart-tick-x')).to.have.length(13);
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={timeScale} tickCount={5} />)
+      shallow(<XTicks xScale={timeScale} tickCount={5} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-x")).to.have.length(5);
+    expect(wrapper.find('line.rct-chart-tick-x')).to.have.length(5);
   });
 
-  it("uses `ticks` to determine which ticks to show", () => {
+  it('uses `ticks` to determine which ticks to show', () => {
     const linearTicks = [-3, 2, 4];
     let wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} ticks={linearTicks} />)
+      shallow(<XTicks xScale={linearScale} ticks={linearTicks} />),
     );
     expectCorrectTickPlacement(wrapper, linearTicks, linearScale);
 
     const timeTicks = [new Date(2009, 4, 10), new Date(2010, 5, 13)];
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={timeScale} ticks={timeTicks} />)
+      shallow(<XTicks xScale={timeScale} ticks={timeTicks} />),
     );
     expectCorrectTickPlacement(wrapper, timeTicks, timeScale);
 
-    const ordinalTicks = ["b", "d"];
+    const ordinalTicks = ['b', 'd'];
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={ordinalScale} ticks={ordinalTicks} />)
+      shallow(<XTicks xScale={ordinalScale} ticks={ordinalTicks} />),
     );
     expectCorrectTickPlacement(wrapper, ordinalTicks, ordinalScale);
   });
 
-  it("uses `tickLength` to determine tick length", () => {
+  it('uses `tickLength` to determine tick length', () => {
     let wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickLength={5} />)
+      shallow(<XTicks xScale={linearScale} tickLength={5} />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
+      .find('line.rct-chart-tick-x')
       .forEach(line => expect(getLineHeight(line)).to.equal(5));
 
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickLength={13} />)
+      shallow(<XTicks xScale={linearScale} tickLength={13} />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
+      .find('line.rct-chart-tick-x')
       .forEach(line => expect(getLineHeight(line)).to.equal(13));
   });
 
-  it("uses `top` to draw the ticks at top of rectangle", () => {
+  it('uses `top` to draw the ticks at top of rectangle', () => {
     const height = 400;
     let wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} height={height} />)
+      shallow(<XTicks xScale={linearScale} height={height} />),
     );
-    expect(wrapper.find("g.rct-chart-ticks-x")).to.have.attr(
-      "transform",
-      `translate(0, ${height})`
+    expect(wrapper.find('g.rct-chart-ticks-x')).to.have.attr(
+      'transform',
+      `translate(0, ${height})`,
     );
 
     wrapper = expectTicksToExist(
-      shallow(<XTicks position="top" xScale={linearScale} height={height} />)
+      shallow(<XTicks position="top" xScale={linearScale} height={height} />),
     );
-    expect(wrapper.find("g.rct-chart-ticks-x")).to.have.attr(
-      "transform",
-      `translate(0, 0)`
+    expect(wrapper.find('g.rct-chart-ticks-x')).to.have.attr(
+      'transform',
+      `translate(0, 0)`,
     );
   });
 
-  it("draws the ticks above/below line if `placement` is passed", () => {
+  it('draws the ticks above/below line if `placement` is passed', () => {
     let wrapper = expectTicksToExist(shallow(<XTicks xScale={linearScale} />));
     wrapper
-      .find("line.rct-chart-tick-x")
-      .forEach(line => expect(line.prop("y2")).to.be.above(0));
+      .find('line.rct-chart-tick-x')
+      .forEach(line => expect(line.prop('y2')).to.be.above(0));
     wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} placement="above" />)
+      shallow(<XTicks xScale={linearScale} placement="above" />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
-      .forEach(line => expect(line.prop("y2")).to.be.below(0));
+      .find('line.rct-chart-tick-x')
+      .forEach(line => expect(line.prop('y2')).to.be.below(0));
 
     wrapper = expectTicksToExist(
-      shallow(<XTicks position="top" xScale={linearScale} />)
+      shallow(<XTicks position="top" xScale={linearScale} />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
-      .forEach(line => expect(line.prop("y2")).to.be.below(0));
+      .find('line.rct-chart-tick-x')
+      .forEach(line => expect(line.prop('y2')).to.be.below(0));
     wrapper = expectTicksToExist(
-      shallow(<XTicks position="top" xScale={linearScale} placement="below" />)
+      shallow(<XTicks position="top" xScale={linearScale} placement="below" />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
-      .forEach(line => expect(line.prop("y2")).to.be.above(0));
+      .find('line.rct-chart-tick-x')
+      .forEach(line => expect(line.prop('y2')).to.be.above(0));
   });
 
-  it("passes className to the ticks", () => {
+  it('passes className to the ticks', () => {
     const wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickClassName={"test-tick-class"} />)
+      shallow(<XTicks xScale={linearScale} tickClassName="test-tick-class" />),
     );
-    expect(wrapper).to.have.descendants("line.test-tick-class");
+    expect(wrapper).to.have.descendants('line.test-tick-class');
   });
 
-  it("passes style to the ticks", () => {
-    const style = { fill: "red" };
+  it('passes style to the ticks', () => {
+    const style = { fill: 'red' };
     const wrapper = expectTicksToExist(
-      shallow(<XTicks xScale={linearScale} tickStyle={style} />)
+      shallow(<XTicks xScale={linearScale} tickStyle={style} />),
     );
     wrapper
-      .find("line.rct-chart-tick-x")
-      .forEach(line => expect(line.prop("style")).to.deep.equal(style));
+      .find('line.rct-chart-tick-x')
+      .forEach(line => expect(line.prop('style')).to.deep.equal(style));
   });
 
-  it("has a static getMargin method which returns the required outer margin space", () => {
+  it('has a static getMargin method which returns the required outer margin space', () => {
     const zeroMargins = {
       marginTop: 0,
       marginBottom: 0,
       marginLeft: 0,
-      marginRight: 0
+      marginRight: 0,
     };
 
     let margin = XTicks.getMargin({
       tickLength: 10,
-      position: "bottom",
-      placement: "below"
+      position: 'bottom',
+      placement: 'below',
     });
     expect(margin).to.deep.equal(_.defaults({ marginBottom: 10 }, zeroMargins));
     margin = XTicks.getMargin({
       tickLength: 10,
-      position: "top",
-      placement: "above"
+      position: 'top',
+      placement: 'above',
     });
     expect(margin).to.deep.equal(_.defaults({ marginTop: 10 }, zeroMargins));
 
     margin = XTicks.getMargin({
       tickLength: 10,
-      position: "bottom",
-      placement: "above"
+      position: 'bottom',
+      placement: 'above',
     });
     expect(margin).to.deep.equal(zeroMargins);
     margin = XTicks.getMargin({
       tickLength: 10,
-      position: "top",
-      placement: "below"
+      position: 'top',
+      placement: 'below',
     });
     expect(margin).to.deep.equal(zeroMargins);
   });

--- a/tests/jsdom/spec/XTicks.spec.js
+++ b/tests/jsdom/spec/XTicks.spec.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint, scaleTime } from 'd3-scale';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
 import chai from 'chai';
 chai.use(chaiEnzyme());
@@ -32,16 +32,13 @@ function getLineHeight(line) {
 }
 
 describe('XTicks', () => {
-  const linearScale = d3
-    .scaleLinear()
+  const linearScale = scaleLinear()
     .domain([-5, 5])
     .range([0, 500]);
-  const timeScale = d3
-    .scaleTime()
+  const timeScale = scaleTime()
     .domain([new Date(2009, 0, 1), new Date(2010, 0, 1)])
     .range([0, 500]);
-  const ordinalScale = d3
-    .scalePoint()
+  const ordinalScale = scalePoint()
     .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 

--- a/tests/jsdom/spec/YGrid.spec.js
+++ b/tests/jsdom/spec/YGrid.spec.js
@@ -1,25 +1,25 @@
-import React from "react";
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { YGrid, YLine } from "../../../src/index.js";
-import { getScaleTicks, getTickDomain } from "../../../src/utils/Scale";
+import { YGrid, YLine } from '../../../src/index.js';
+import { getScaleTicks, getTickDomain } from '../../../src/utils/Scale';
 
-describe("YGrid", () => {
+describe('YGrid', () => {
   const props = {
     width: 10,
     spacingTop: 10,
     spacingBottom: 10,
     spacingLeft: 10,
     spacingRight: 10,
-    lineClassName: "ygrid-line-class",
-    lineStyle: { stroke: "blue" },
-    yScale: d3.scaleLinear().domain([0, 100])
+    lineClassName: 'ygrid-line-class',
+    lineStyle: { stroke: 'blue' },
+    yScale: d3.scaleLinear().domain([0, 100]),
   };
 
-  it("passes props correctly to YLine", () => {
+  it('passes props correctly to YLine', () => {
     const yGrid = mount(<YGrid {...props} />);
     const yLines = yGrid.find(YLine);
 
@@ -37,13 +37,13 @@ describe("YGrid", () => {
     });
   });
 
-  it("renders the correct amount of YLines given tickCount", () => {
+  it('renders the correct amount of YLines given tickCount', () => {
     const tickCount = 50;
     const yGrid = mount(<YGrid {...props} tickCount={tickCount} />);
-    const group = yGrid.find("g");
+    const group = yGrid.find('g');
 
     expect(group).to.have.lengthOf(1);
-    expect(group.getDOMNode().className).to.equal("rct-chart-grid-y");
+    expect(group.getDOMNode().className).to.equal('rct-chart-grid-y');
 
     const yLines = yGrid.find(YLine);
     const numTicksMade = getScaleTicks(props.yScale, null, tickCount);
@@ -51,25 +51,25 @@ describe("YGrid", () => {
     expect(yLines).to.have.lengthOf(numTicksMade.length);
   });
 
-  it("renders the correct amount of YLines given ticks", () => {
+  it('renders the correct amount of YLines given ticks', () => {
     const ticks = [0, 25, 50, 100];
     const yGrid = mount(<YGrid {...props} ticks={ticks} />);
-    const group = yGrid.find("g");
+    const group = yGrid.find('g');
 
     expect(group).to.have.lengthOf(1);
-    expect(group.getDOMNode().className).to.equal("rct-chart-grid-y");
+    expect(group.getDOMNode().className).to.equal('rct-chart-grid-y');
 
     const yLines = yGrid.find(YLine);
     expect(yLines).to.have.lengthOf(ticks.length);
   });
 
-  it("getTickDomain works as expected", () => {
+  it('getTickDomain works as expected', () => {
     const ticks = [0, 25, 50, 100];
 
     const result = getTickDomain(props.yScale, { ...props, ticks });
 
     expect(YGrid.getTickDomain({ ...props, ticks })).to.eql({
-      yTickDomain: result
+      yTickDomain: result,
     });
   });
 });

--- a/tests/jsdom/spec/YGrid.spec.js
+++ b/tests/jsdom/spec/YGrid.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import * as d3 from 'd3';
-import _ from 'lodash';
+import { scaleLinear } from 'd3-scale';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
@@ -16,7 +15,7 @@ describe('YGrid', () => {
     spacingRight: 10,
     lineClassName: 'ygrid-line-class',
     lineStyle: { stroke: 'blue' },
-    yScale: d3.scaleLinear().domain([0, 100]),
+    yScale: scaleLinear().domain([0, 100]),
   };
 
   it('passes props correctly to YLine', () => {

--- a/tests/jsdom/spec/YLine.spec.js
+++ b/tests/jsdom/spec/YLine.spec.js
@@ -1,7 +1,6 @@
-import _ from 'lodash';
-import * as d3 from 'd3';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { scaleLinear, scaleTime, scalePoint } from 'd3-scale';
+import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
 import chai from 'chai';
 chai.use(chaiEnzyme());
@@ -29,16 +28,13 @@ function getLineWidth(line) {
 }
 
 describe('YLine', () => {
-  const linearScale = d3
-    .scaleLinear()
+  const linearScale = scaleLinear()
     .domain([-5, 5])
     .range([0, 500]);
-  const timeScale = d3
-    .scaleTime()
+  const timeScale = scaleTime()
     .domain([new Date(2009, 0, 1), new Date(2010, 0, 1)])
     .range([0, 500]);
-  const ordinalScale = d3
-    .scalePoint()
+  const ordinalScale = scalePoint()
     .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 

--- a/tests/jsdom/spec/YLine.spec.js
+++ b/tests/jsdom/spec/YLine.spec.js
@@ -1,34 +1,34 @@
-import _ from "lodash";
-import * as d3 from "d3";
-import React from "react";
-import { shallow, mount } from "enzyme";
-import chaiEnzyme from "chai-enzyme";
-import chai from "chai";
+import _ from 'lodash';
+import * as d3 from 'd3';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai from 'chai';
 chai.use(chaiEnzyme());
 const { expect } = chai;
 
-import YLine from "../../../src/YLine";
+import YLine from '../../../src/YLine';
 
 function findLine(wrapper) {
-  return wrapper.find("line.rct-chart-line-y").first();
+  return wrapper.find('line.rct-chart-line-y').first();
 }
 
 function expectCorrectLinePlacement(wrapper, value, scale) {
-  const lines = wrapper.find("line.rct-chart-line-y");
+  const lines = wrapper.find('line.rct-chart-line-y');
   expect(lines).to.have.length(1);
   const line = lines.first();
-  expect(line.first().prop("y1")).to.equal(scale(value));
-  expect(line.first().prop("y2")).to.equal(scale(value));
+  expect(line.first().prop('y1')).to.equal(scale(value));
+  expect(line.first().prop('y2')).to.equal(scale(value));
   return wrapper;
 }
 
 function getLineWidth(line) {
-  const x1 = +line.prop("x1") || 0;
-  const x2 = +line.prop("x2");
+  const x1 = +line.prop('x1') || 0;
+  const x2 = +line.prop('x2');
   return Math.abs(x2 - x1);
 }
 
-describe("YLine", () => {
+describe('YLine', () => {
   const linearScale = d3
     .scaleLinear()
     .domain([-5, 5])
@@ -39,39 +39,39 @@ describe("YLine", () => {
     .range([0, 500]);
   const ordinalScale = d3
     .scalePoint()
-    .domain(["a", "b", "c", "d"])
+    .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 
   const linearValue = 2;
   const timeValue = new Date(2009, 9, 19);
-  const ordinalValue = "c";
+  const ordinalValue = 'c';
   const commonProps = { spacing: { top: 0, bottom: 0, left: 0, right: 0 } };
 
-  it("renders a .chart-line-x element in the correct place", () => {
+  it('renders a .chart-line-x element in the correct place', () => {
     let wrapper = shallow(
-      <YLine yScale={linearScale} value={linearValue} {...commonProps} />
+      <YLine yScale={linearScale} value={linearValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, linearValue, linearScale);
 
     wrapper = shallow(
-      <YLine yScale={timeScale} value={timeValue} {...commonProps} />
+      <YLine yScale={timeScale} value={timeValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, timeValue, timeScale);
 
     wrapper = shallow(
-      <YLine yScale={ordinalScale} value={ordinalValue} {...commonProps} />
+      <YLine yScale={ordinalScale} value={ordinalValue} {...commonProps} />,
     );
     expectCorrectLinePlacement(wrapper, ordinalValue, ordinalScale);
   });
 
-  it("renders a line with the correct width", () => {
+  it('renders a line with the correct width', () => {
     let wrapper = shallow(
       <YLine
         yScale={linearScale}
         value={linearValue}
         width={200}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineWidth(findLine(wrapper))).to.equal(200);
 
@@ -81,34 +81,34 @@ describe("YLine", () => {
         value={linearValue}
         width={400}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineWidth(findLine(wrapper))).to.equal(400);
   });
 
-  it("passes className to the line", () => {
+  it('passes className to the line', () => {
     const wrapper = shallow(
       <YLine
         yScale={linearScale}
         value={linearValue}
-        className={"test-line-class"}
+        className="test-line-class"
         {...commonProps}
-      />
+      />,
     );
-    expect(wrapper).to.have.descendants("line.test-line-class");
+    expect(wrapper).to.have.descendants('line.test-line-class');
   });
 
-  it("passes style to the line", () => {
-    const style = { fill: "red" };
+  it('passes style to the line', () => {
+    const style = { fill: 'red' };
     const wrapper = shallow(
       <YLine
         yScale={linearScale}
         value={linearValue}
         style={style}
         {...commonProps}
-      />
+      />,
     );
-    expect(findLine(wrapper).prop("style")).to.deep.equal(style);
+    expect(findLine(wrapper).prop('style')).to.deep.equal(style);
   });
 
   it("limits the line's width using xLimit", () => {
@@ -120,7 +120,7 @@ describe("YLine", () => {
         value={linearValue}
         xLimit={limit}
         {...commonProps}
-      />
+      />,
     );
     expect(getLineWidth(findLine(wrapper))).to.equal(linearScale(limit));
   });

--- a/tests/jsdom/spec/YTicks.spec.js
+++ b/tests/jsdom/spec/YTicks.spec.js
@@ -1,37 +1,37 @@
-import _ from "lodash";
-import * as d3 from "d3";
-import React from "react";
-import { shallow, mount } from "enzyme";
-import chaiEnzyme from "chai-enzyme";
-import chai from "chai";
+import _ from 'lodash';
+import * as d3 from 'd3';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai from 'chai';
 chai.use(chaiEnzyme());
 const { expect } = chai;
 
-import { YTicks } from "../../../src/index.js";
+import { YTicks } from '../../../src/index.js';
 
 function expectTicksToExist(wrapper) {
-  const ticksGroup = wrapper.find("g.rct-chart-ticks-y");
+  const ticksGroup = wrapper.find('g.rct-chart-ticks-y');
   expect(ticksGroup).to.have.length(1);
-  expect(ticksGroup).to.have.descendants("line.rct-chart-tick-y");
+  expect(ticksGroup).to.have.descendants('line.rct-chart-tick-y');
   return wrapper;
 }
 
 function expectCorrectTickPlacement(wrapper, ticks, scale) {
-  const tickLines = wrapper.find("line.rct-chart-tick-y");
+  const tickLines = wrapper.find('line.rct-chart-tick-y');
   expect(tickLines).to.have.length(ticks.length);
   tickLines.forEach((line, i) => {
-    expect(Math.round(+line.prop("y1"))).to.equal(Math.round(scale(ticks[i])));
+    expect(Math.round(+line.prop('y1'))).to.equal(Math.round(scale(ticks[i])));
   });
   return wrapper;
 }
 
 function getLineWidth(line) {
-  const y1 = +line.prop("x1") || 0;
-  const y2 = +line.prop("x2");
+  const y1 = +line.prop('x1') || 0;
+  const y2 = +line.prop('x2');
   return Math.abs(y2 - y1);
 }
 
-describe("YTicks", () => {
+describe('YTicks', () => {
   const linearScale = d3
     .scaleLinear()
     .domain([-5, 5])
@@ -42,166 +42,166 @@ describe("YTicks", () => {
     .range([0, 500]);
   const ordinalScale = d3
     .scalePoint()
-    .domain(["a", "b", "c", "d"])
+    .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 
-  it("renders a .rct-chart-ticks-y element with tick lines", () => {
+  it('renders a .rct-chart-ticks-y element with tick lines', () => {
     expectTicksToExist(shallow(<YTicks yScale={linearScale} />));
     expectTicksToExist(shallow(<YTicks yScale={ordinalScale} />));
     expectTicksToExist(shallow(<YTicks yScale={timeScale} />));
   });
 
-  it("uses `tickCount` to determine approx. # of ticks to display on number/time scales", () => {
+  it('uses `tickCount` to determine approx. # of ticks to display on number/time scales', () => {
     let wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickCount={11} />)
+      shallow(<YTicks yScale={linearScale} tickCount={11} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-y")).to.have.length(11);
+    expect(wrapper.find('line.rct-chart-tick-y')).to.have.length(11);
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickCount={3} />)
+      shallow(<YTicks yScale={linearScale} tickCount={3} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-y")).to.have.length(3);
+    expect(wrapper.find('line.rct-chart-tick-y')).to.have.length(3);
 
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={timeScale} tickCount={13} />)
+      shallow(<YTicks yScale={timeScale} tickCount={13} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-y")).to.have.length(13);
+    expect(wrapper.find('line.rct-chart-tick-y')).to.have.length(13);
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={timeScale} tickCount={5} />)
+      shallow(<YTicks yScale={timeScale} tickCount={5} />),
     );
-    expect(wrapper.find("line.rct-chart-tick-y")).to.have.length(5);
+    expect(wrapper.find('line.rct-chart-tick-y')).to.have.length(5);
   });
 
-  it("uses `ticks` to determine which ticks to show", () => {
+  it('uses `ticks` to determine which ticks to show', () => {
     const linearTicks = [-3, 2, 4];
     let wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} ticks={linearTicks} />)
+      shallow(<YTicks yScale={linearScale} ticks={linearTicks} />),
     );
     expectCorrectTickPlacement(wrapper, linearTicks, linearScale);
 
     const timeTicks = [new Date(2009, 4, 10), new Date(2010, 5, 13)];
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={timeScale} ticks={timeTicks} />)
+      shallow(<YTicks yScale={timeScale} ticks={timeTicks} />),
     );
     expectCorrectTickPlacement(wrapper, timeTicks, timeScale);
 
-    const ordinalTicks = ["b", "d"];
+    const ordinalTicks = ['b', 'd'];
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={ordinalScale} ticks={ordinalTicks} />)
+      shallow(<YTicks yScale={ordinalScale} ticks={ordinalTicks} />),
     );
     expectCorrectTickPlacement(wrapper, ordinalTicks, ordinalScale);
   });
 
-  it("uses `tickLength` to determine tick length", () => {
+  it('uses `tickLength` to determine tick length', () => {
     let wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickLength={5} />)
+      shallow(<YTicks yScale={linearScale} tickLength={5} />),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
+      .find('line.rct-chart-tick-y')
       .forEach(line => expect(getLineWidth(line)).to.equal(5));
 
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickLength={13} />)
+      shallow(<YTicks yScale={linearScale} tickLength={13} />),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
+      .find('line.rct-chart-tick-y')
       .forEach(line => expect(getLineWidth(line)).to.equal(13));
   });
 
-  it("uses `right` to draw the ticks right of rectangle", () => {
+  it('uses `right` to draw the ticks right of rectangle', () => {
     const width = 400;
     let wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} width={width} />)
+      shallow(<YTicks yScale={linearScale} width={width} />),
     );
-    expect(wrapper.find("g.rct-chart-ticks-y")).to.have.attr(
-      "transform",
-      `translate(0, 0)`
+    expect(wrapper.find('g.rct-chart-ticks-y')).to.have.attr(
+      'transform',
+      `translate(0, 0)`,
     );
 
     wrapper = expectTicksToExist(
-      shallow(<YTicks position="right" yScale={linearScale} width={width} />)
+      shallow(<YTicks position="right" yScale={linearScale} width={width} />),
     );
-    expect(wrapper.find("g.rct-chart-ticks-y")).to.have.attr(
-      "transform",
-      `translate(${width}, 0)`
+    expect(wrapper.find('g.rct-chart-ticks-y')).to.have.attr(
+      'transform',
+      `translate(${width}, 0)`,
     );
   });
 
-  it("draws the ticks above/below line if `placement` is passed", () => {
+  it('draws the ticks above/below line if `placement` is passed', () => {
     let wrapper = expectTicksToExist(shallow(<YTicks yScale={linearScale} />));
     wrapper
-      .find("line.rct-chart-tick-y")
-      .forEach(line => expect(line.prop("x2")).to.be.below(0));
+      .find('line.rct-chart-tick-y')
+      .forEach(line => expect(line.prop('x2')).to.be.below(0));
     wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} placement="before" />)
+      shallow(<YTicks yScale={linearScale} placement="before" />),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
-      .forEach(line => expect(line.prop("x2")).to.be.below(0));
+      .find('line.rct-chart-tick-y')
+      .forEach(line => expect(line.prop('x2')).to.be.below(0));
 
     wrapper = expectTicksToExist(
-      shallow(<YTicks position="right" yScale={linearScale} />)
+      shallow(<YTicks position="right" yScale={linearScale} />),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
-      .forEach(line => expect(line.prop("x2")).to.be.above(0));
+      .find('line.rct-chart-tick-y')
+      .forEach(line => expect(line.prop('x2')).to.be.above(0));
     wrapper = expectTicksToExist(
       shallow(
-        <YTicks position="right" yScale={linearScale} placement="after" />
-      )
+        <YTicks position="right" yScale={linearScale} placement="after" />,
+      ),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
-      .forEach(line => expect(line.prop("x2")).to.be.above(0));
+      .find('line.rct-chart-tick-y')
+      .forEach(line => expect(line.prop('x2')).to.be.above(0));
   });
 
-  it("passes className to the ticks", () => {
+  it('passes className to the ticks', () => {
     const wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickClassName={"test-tick-class"} />)
+      shallow(<YTicks yScale={linearScale} tickClassName="test-tick-class" />),
     );
-    expect(wrapper).to.have.descendants("line.test-tick-class");
+    expect(wrapper).to.have.descendants('line.test-tick-class');
   });
 
-  it("passes style to the ticks", () => {
-    const style = { fill: "red" };
+  it('passes style to the ticks', () => {
+    const style = { fill: 'red' };
     const wrapper = expectTicksToExist(
-      shallow(<YTicks yScale={linearScale} tickStyle={style} />)
+      shallow(<YTicks yScale={linearScale} tickStyle={style} />),
     );
     wrapper
-      .find("line.rct-chart-tick-y")
-      .forEach(line => expect(line.prop("style")).to.deep.equal(style));
+      .find('line.rct-chart-tick-y')
+      .forEach(line => expect(line.prop('style')).to.deep.equal(style));
   });
 
-  it("has a static getMargin method which returns the required outer margin space", () => {
+  it('has a static getMargin method which returns the required outer margin space', () => {
     const zeroMargins = {
       marginTop: 0,
       marginBottom: 0,
       marginLeft: 0,
-      marginRight: 0
+      marginRight: 0,
     };
 
     let margin = YTicks.getMargin({
       tickLength: 10,
-      position: "left",
-      placement: "before"
+      position: 'left',
+      placement: 'before',
     });
     expect(margin).to.deep.equal(_.defaults({ marginLeft: 10 }, zeroMargins));
     margin = YTicks.getMargin({
       tickLength: 10,
-      position: "left",
-      placement: "after"
+      position: 'left',
+      placement: 'after',
     });
     expect(margin).to.deep.equal(zeroMargins);
 
     margin = YTicks.getMargin({
       tickLength: 10,
-      position: "right",
-      placement: "before"
+      position: 'right',
+      placement: 'before',
     });
     expect(margin).to.deep.equal(zeroMargins);
     margin = YTicks.getMargin({
       tickLength: 10,
-      position: "right",
-      placement: "after"
+      position: 'right',
+      placement: 'after',
     });
     expect(margin).to.deep.equal(_.defaults({ marginRight: 10 }, zeroMargins));
   });

--- a/tests/jsdom/spec/YTicks.spec.js
+++ b/tests/jsdom/spec/YTicks.spec.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint, scaleTime } from 'd3-scale';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
 import chai from 'chai';
 chai.use(chaiEnzyme());
@@ -32,16 +32,13 @@ function getLineWidth(line) {
 }
 
 describe('YTicks', () => {
-  const linearScale = d3
-    .scaleLinear()
+  const linearScale = scaleLinear()
     .domain([-5, 5])
     .range([0, 500]);
-  const timeScale = d3
-    .scaleTime()
+  const timeScale = scaleTime()
     .domain([new Date(2009, 0, 1), new Date(2010, 0, 1)])
     .range([0, 500]);
-  const ordinalScale = d3
-    .scalePoint()
+  const ordinalScale = scalePoint()
     .domain(['a', 'b', 'c', 'd'])
     .range([0, 300]);
 

--- a/tests/jsdom/spec/ZoomContainer.spec.js
+++ b/tests/jsdom/spec/ZoomContainer.spec.js
@@ -1,62 +1,62 @@
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
-import { mount } from "enzyme";
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
-import { XYPlot, ZoomContainer } from "../../../src/index.js";
-import { getValue } from "../../../src/utils/Data.js";
+import { XYPlot, ZoomContainer } from '../../../src/index.js';
+import { getValue } from '../../../src/utils/Data.js';
 
-describe("ZoomContainer", () => {
+describe('ZoomContainer', () => {
   const uncontrolledProps = {
     width: 500,
     height: 500,
-    scaleExtent: [0.5, 2]
+    scaleExtent: [0.5, 2],
   };
 
   const controlledProps = {
     ...uncontrolledProps,
-    controlled: true
+    controlled: true,
   };
 
-  it("passes props correctly to DOM", () => {
+  it('passes props correctly to DOM', () => {
     const zoomContainer = mount(<ZoomContainer {...uncontrolledProps} />);
 
-    let svg = zoomContainer.find("svg").instance();
-    let group = zoomContainer.find("g").instance();
+    let svg = zoomContainer.find('svg').instance();
+    let group = zoomContainer.find('g').instance();
 
-    expect(parseInt(svg.getAttribute("width"))).to.equal(
-      uncontrolledProps.width
+    expect(parseInt(svg.getAttribute('width'))).to.equal(
+      uncontrolledProps.width,
     );
-    expect(parseInt(svg.getAttribute("height"))).to.equal(
-      uncontrolledProps.height
+    expect(parseInt(svg.getAttribute('height'))).to.equal(
+      uncontrolledProps.height,
     );
-    expect(parseInt(group.getAttribute("width"))).to.equal(
-      uncontrolledProps.width
+    expect(parseInt(group.getAttribute('width'))).to.equal(
+      uncontrolledProps.width,
     );
-    expect(parseInt(group.getAttribute("height"))).to.equal(
-      uncontrolledProps.height
+    expect(parseInt(group.getAttribute('height'))).to.equal(
+      uncontrolledProps.height,
     );
 
     const controlledZoomContainer = mount(
-      <ZoomContainer {...controlledProps} />
+      <ZoomContainer {...controlledProps} />,
     );
 
-    svg = controlledZoomContainer.find("svg").instance();
-    group = controlledZoomContainer.find("g").instance();
+    svg = controlledZoomContainer.find('svg').instance();
+    group = controlledZoomContainer.find('g').instance();
 
-    expect(parseInt(svg.getAttribute("width"))).to.equal(controlledProps.width);
-    expect(parseInt(svg.getAttribute("height"))).to.equal(
-      controlledProps.height
+    expect(parseInt(svg.getAttribute('width'))).to.equal(controlledProps.width);
+    expect(parseInt(svg.getAttribute('height'))).to.equal(
+      controlledProps.height,
     );
-    expect(parseInt(group.getAttribute("width"))).to.equal(
-      controlledProps.width
+    expect(parseInt(group.getAttribute('width'))).to.equal(
+      controlledProps.width,
     );
-    expect(parseInt(group.getAttribute("height"))).to.equal(
-      controlledProps.height
+    expect(parseInt(group.getAttribute('height'))).to.equal(
+      controlledProps.height,
     );
   });
 
-  it("passes props correctly to d3 zoom", () => {
+  it('passes props correctly to d3 zoom', () => {
     const d3Props = {
       extent: [[0, 0], [1, 1]],
       scaleExtent: [0.5, 2],
@@ -67,59 +67,59 @@ describe("ZoomContainer", () => {
       constrain: () => {},
       filter: () => {},
       touchable: () => {},
-      wheelDelta: () => {}
+      wheelDelta: () => {},
     };
 
     const zoomContainer = mount(
-      <ZoomContainer {...uncontrolledProps} {...d3Props} />
+      <ZoomContainer {...uncontrolledProps} {...d3Props} />,
     );
 
     const d3Zoom = zoomContainer.instance().zoom;
 
-    expect(d3Zoom.extent).to.be.a("function");
-    expect(d3Zoom.scaleExtent).to.be.a("function");
-    expect(d3Zoom.translateExtent).to.be.a("function");
-    expect(d3Zoom.clickDistance).to.be.a("function");
-    expect(d3Zoom.duration).to.be.a("function");
-    expect(d3Zoom.interpolate).to.be.a("function");
-    expect(d3Zoom.constrain).to.be.a("function");
-    expect(d3Zoom.filter).to.be.a("function");
-    expect(d3Zoom.touchable).to.be.a("function");
-    expect(d3Zoom.wheelDelta).to.be.a("function");
+    expect(d3Zoom.extent).to.be.a('function');
+    expect(d3Zoom.scaleExtent).to.be.a('function');
+    expect(d3Zoom.translateExtent).to.be.a('function');
+    expect(d3Zoom.clickDistance).to.be.a('function');
+    expect(d3Zoom.duration).to.be.a('function');
+    expect(d3Zoom.interpolate).to.be.a('function');
+    expect(d3Zoom.constrain).to.be.a('function');
+    expect(d3Zoom.filter).to.be.a('function');
+    expect(d3Zoom.touchable).to.be.a('function');
+    expect(d3Zoom.wheelDelta).to.be.a('function');
   });
 
-  it("passes zoom props correctly when controlled", () => {
+  it('passes zoom props correctly when controlled', () => {
     const zoomContainer = mount(<ZoomContainer {...controlledProps} />);
 
-    expect(zoomContainer.prop("zoomX")).to.equal(0);
-    expect(zoomContainer.prop("zoomY")).to.equal(0);
-    expect(zoomContainer.prop("zoomScale")).to.equal(1);
-    expect(zoomContainer.state("lastZoomTransform").k).to.eql(1);
-    expect(zoomContainer.state("lastZoomTransform").x).to.eql(0);
-    expect(zoomContainer.state("lastZoomTransform").y).to.eql(0);
+    expect(zoomContainer.prop('zoomX')).to.equal(0);
+    expect(zoomContainer.prop('zoomY')).to.equal(0);
+    expect(zoomContainer.prop('zoomScale')).to.equal(1);
+    expect(zoomContainer.state('lastZoomTransform').k).to.eql(1);
+    expect(zoomContainer.state('lastZoomTransform').x).to.eql(0);
+    expect(zoomContainer.state('lastZoomTransform').y).to.eql(0);
 
     zoomContainer.setProps({ zoomX: 100, zoomY: 100, zoomScale: 2 });
 
-    expect(zoomContainer.state("lastZoomTransform").k).to.eql(2);
-    expect(zoomContainer.state("lastZoomTransform").x).to.eql(100);
-    expect(zoomContainer.state("lastZoomTransform").y).to.eql(100);
+    expect(zoomContainer.state('lastZoomTransform').k).to.eql(2);
+    expect(zoomContainer.state('lastZoomTransform').x).to.eql(100);
+    expect(zoomContainer.state('lastZoomTransform').y).to.eql(100);
   });
 
-  it("renders correctly", () => {
+  it('renders correctly', () => {
     const zoomContainer = mount(<ZoomContainer {...uncontrolledProps} />);
 
-    let svg = zoomContainer.find("svg");
-    let group = zoomContainer.find("g");
+    let svg = zoomContainer.find('svg');
+    let group = zoomContainer.find('g');
 
     expect(svg.length).to.equal(1);
     expect(group.length).to.equal(1);
 
     const controlledZoomContainer = mount(
-      <ZoomContainer {...controlledProps} />
+      <ZoomContainer {...controlledProps} />,
     );
 
-    svg = controlledZoomContainer.find("svg");
-    group = controlledZoomContainer.find("g");
+    svg = controlledZoomContainer.find('svg');
+    group = controlledZoomContainer.find('g');
 
     expect(svg.length).to.equal(1);
     expect(group.length).to.equal(1);

--- a/tests/jsdom/spec/ZoomContainer.spec.js
+++ b/tests/jsdom/spec/ZoomContainer.spec.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import * as d3 from 'd3';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { XYPlot, ZoomContainer } from '../../../src/index.js';
-import { getValue } from '../../../src/utils/Data.js';
+import { ZoomContainer } from '../../../src/index.js';
 
 describe('ZoomContainer', () => {
   const uncontrolledProps = {

--- a/tests/jsdom/spec/examples.spec.js
+++ b/tests/jsdom/spec/examples.spec.js
@@ -1,7 +1,6 @@
-import _ from 'lodash';
 import React from 'react';
 // import TestUtils from 'react-addons-test-utils';
-import { expect } from 'chai';
+// import { expect } from 'chai';
 
 // TODO: fix this to work with new examples structure??
 

--- a/tests/jsdom/spec/examples.spec.js
+++ b/tests/jsdom/spec/examples.spec.js
@@ -1,7 +1,7 @@
-import _ from "lodash";
-import React from "react";
+import _ from 'lodash';
+import React from 'react';
 // import TestUtils from 'react-addons-test-utils';
-import { expect } from "chai";
+import { expect } from 'chai';
 
 // TODO: fix this to work with new examples structure??
 

--- a/tests/jsdom/spec/resolveXYScales.spec.js
+++ b/tests/jsdom/spec/resolveXYScales.spec.js
@@ -1,16 +1,16 @@
-import _ from "lodash";
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
-import { mount, shallow } from "enzyme";
+import _ from 'lodash';
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
 
-import { isValidScale } from "../../../src/utils/Scale";
-import { innerRangeX, innerRangeY } from "../../../src/utils/Margin";
+import { isValidScale } from '../../../src/utils/Scale';
+import { innerRangeX, innerRangeY } from '../../../src/utils/Margin';
 
-import resolveXYScales from "../../../src/utils/resolveXYScales";
+import resolveXYScales from '../../../src/utils/resolveXYScales';
 
 class NotImplementedError extends Error {
-  constructor(message = "Not Implemented Yet") {
+  constructor(message = 'Not Implemented Yet') {
     super(message);
   }
 }
@@ -21,8 +21,8 @@ function expectRefAndDeepEqual(a, b) {
 }
 
 function expectXYScales(scales) {
-  expect(scales).to.be.an("object");
-  ["x", "y"].forEach(k => {
+  expect(scales).to.be.an('object');
+  ['x', 'y'].forEach(k => {
     expect(scales).to.have.property(k);
     expect(isValidScale(scales[k])).to.equal(true);
   });
@@ -30,36 +30,36 @@ function expectXYScales(scales) {
 
 function expectXYScaledComponent(
   rendered,
-  { width, height, scaleType, domain, margin, range }
+  { width, height, scaleType, domain, margin, range },
 ) {
   // checks that a given rendered component has been created with XY scales/margin
   // that match the expected domain, range & margin
   // if range not provided, it should be width/height minus margins
   range = range || {
     x: innerRangeX(width, margin),
-    y: innerRangeY(height, margin)
+    y: innerRangeY(height, margin),
   };
-  expect(scaleType).to.be.an("object");
-  console.log("expected domains", domain);
-  console.log("expected range", range);
+  expect(scaleType).to.be.an('object');
+  console.log('expected domains', domain);
+  console.log('expected range', range);
 
-  expect(rendered.props).to.be.an("object");
+  expect(rendered.props).to.be.an('object');
   expect(rendered.props.margin).to.deep.equal(margin);
 
   const renderedScale = rendered.props.scale;
   expectXYScales(renderedScale);
-  ["x", "y"].forEach(k => {
+  ['x', 'y'].forEach(k => {
     expect(rendered.props.scaleType[k]).to.equal(scaleType[k]);
-    console.log("domain", renderedScale[k].domain());
-    console.log("expected domain", domain[k]);
+    console.log('domain', renderedScale[k].domain());
+    console.log('expected domain', domain[k]);
     expect(renderedScale[k].domain()).to.deep.equal(domain[k]);
-    if (scaleType[k] === "ordinal")
+    if (scaleType[k] === 'ordinal')
       expect(renderedScale[k].range()).to.deep.equal(
         d3
           .scaleOrdinal()
           .domain(domain[k])
           .rangePoints(range[k])
-          .range()
+          .range(),
       );
     else expect(renderedScale[k].range()).to.deep.equal(range[k]);
   });
@@ -67,46 +67,46 @@ function expectXYScaledComponent(
 
 function expectXYScaledComponentEnzyme(
   rendered,
-  { width, height, scaleType, domain, margin, range }
+  { width, height, scaleType, domain, margin, range },
 ) {
   // checks that a given rendered component has been created with XY scales/margin
   // that match the expected domain, range & margin
   // if range not provided, it should be width/height minus margins
   range = range || {
     x: innerRangeX(width, margin),
-    y: innerRangeY(height, margin)
+    y: innerRangeY(height, margin),
   };
-  expect(scaleType).to.be.an("object");
+  expect(scaleType).to.be.an('object');
 
   expect(rendered.props().margin).to.deep.equal(margin);
 
   const renderedScale = rendered.props().scale;
   expectXYScales(renderedScale);
-  ["x", "y"].forEach(k => {
+  ['x', 'y'].forEach(k => {
     expect(rendered.props().scaleType[k]).to.equal(scaleType[k]);
-    console.log("domain", renderedScale[k].domain());
-    console.log("expected domain", domain[k]);
+    console.log('domain', renderedScale[k].domain());
+    console.log('expected domain', domain[k]);
     expect(renderedScale[k].domain()).to.deep.equal(domain[k]);
-    if (scaleType[k] === "ordinal")
+    if (scaleType[k] === 'ordinal')
       expect(renderedScale[k].range()).to.deep.equal(
         d3
           .scaleOrdinal()
           .domain(domain[k])
           .rangePoints(range[k])
-          .range()
+          .range(),
       );
     else expect(renderedScale[k].range()).to.deep.equal(range[k]);
   });
 }
 
-describe("resolveXYScales", () => {
-  const customScaleType = { xScaleType: "ordinal", yScaleType: "linear" };
+describe('resolveXYScales', () => {
+  const customScaleType = { xScaleType: 'ordinal', yScaleType: 'linear' };
   const customDomain = { xDomain: [-5, 5], yDomain: [0, 10] };
   const customMargin = {
     marginTop: 10,
     marginBottom: 20,
     marginLeft: 30,
-    marginRight: 40
+    marginRight: 40,
   };
   const width = 500;
   const height = 400;
@@ -156,7 +156,7 @@ describe("resolveXYScales", () => {
         marginLeft,
         marginRight,
         xDomain,
-        yDomain
+        yDomain,
       } = this.props;
       const newChildren = React.Children.map(
         this.props.children,
@@ -173,16 +173,16 @@ describe("resolveXYScales", () => {
             marginLeft,
             marginRight,
             xDomain,
-            yDomain
+            yDomain,
           });
-        }
+        },
       );
       return <div>{newChildren}</div>;
     }
   }
   const XYContainerChart = resolveXYScales(ContainerChart);
 
-  it("passes XY scales and margins through if both are provided", () => {
+  it('passes XY scales and margins through if both are provided', () => {
     const props = {
       xScale: d3
         .scaleLinear()
@@ -195,35 +195,35 @@ describe("resolveXYScales", () => {
       marginTop: 11,
       marginBottom: 21,
       marginLeft: 31,
-      marginRight: 41
+      marginRight: 41,
     };
     const wrapped = mount(<XYChart {...props} />);
     const rendered = wrapped.find(Chart);
 
     [
-      "xScale",
-      "yScale",
-      "marginTop",
-      "marginBottom",
-      "marginLeft",
-      "marginRight"
+      'xScale',
+      'yScale',
+      'marginTop',
+      'marginBottom',
+      'marginLeft',
+      'marginRight',
     ].forEach(propKey => {
       expectRefAndDeepEqual(rendered.props()[propKey], props[propKey]);
     });
   });
 
-  it("creates scales from scaleType, size, domain & margins", () => {
+  it('creates scales from scaleType, size, domain & margins', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "ordinal",
+      xScaleType: 'linear',
+      yScaleType: 'ordinal',
       xDomain: [-50, 50],
       yDomain: [-100, 100],
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
 
     const wrapped = mount(<XYChart {...props} />);
@@ -237,15 +237,15 @@ describe("resolveXYScales", () => {
     expect(renderedYScale.domain()).to.deep.equal(props.yDomain);
     expect(renderedXScale.range()).to.deep.equal([
       0,
-      width - (props.marginLeft + props.marginRight)
+      width - (props.marginLeft + props.marginRight),
     ]);
     expect(renderedYScale.range()).to.deep.equal([
       height - (props.marginTop + props.marginBottom),
-      0
+      0,
     ]);
   });
 
-  it("infers scaleType from Component.getScaleType", () => {
+  it('infers scaleType from Component.getScaleType', () => {
     const props = {
       width,
       height,
@@ -254,7 +254,7 @@ describe("resolveXYScales", () => {
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
 
     const wrapped = mount(<XYChartWithCustomScaleType {...props} />);
@@ -264,26 +264,26 @@ describe("resolveXYScales", () => {
     expect(rendered.props().yScaleType).to.equal(customScaleType.yScaleType);
   });
 
-  it("infers scaleType from data", () => {
+  it('infers scaleType from data', () => {
     const props = {
       width,
       height,
-      data: [[12, "a"], [18, "b"], [22, "c"]],
+      data: [[12, 'a'], [18, 'b'], [22, 'c']],
       x: d => d[0],
       y: d => d[1],
       xDomain: [12, 22],
-      yDomain: ["a", "b", "c"],
+      yDomain: ['a', 'b', 'c'],
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
 
     const wrapped = mount(<XYChart {...props} />);
     const rendered = wrapped.find(Chart);
 
-    expect(rendered.props().xScaleType).to.equal("linear");
-    expect(rendered.props().yScaleType).to.deep.equal("ordinal");
+    expect(rendered.props().xScaleType).to.equal('linear');
+    expect(rendered.props().yScaleType).to.deep.equal('ordinal');
   });
 
   // todo: fix this (only matters in edge case)
@@ -302,21 +302,21 @@ describe("resolveXYScales", () => {
   //   expect(rendered.props().scaleType).to.deep.equal(customScaleType);
   // });
 
-  it("infers scaleType from children data", () => {
+  it('infers scaleType from children data', () => {
     const props = {
       width,
       height,
       xDomain: [12, 22],
-      yDomain: ["a", "b", "c"],
+      yDomain: ['a', 'b', 'c'],
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const chartProps = {
-      data: [[12, "a"], [18, "b"], [22, "c"]],
+      data: [[12, 'a'], [18, 'b'], [22, 'c']],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
 
     const tree = (
@@ -327,20 +327,20 @@ describe("resolveXYScales", () => {
     const wrapped = mount(tree);
     const rendered = wrapped.find(ContainerChart);
 
-    expect(rendered.props().xScaleType).to.equal("linear");
-    expect(rendered.props().yScaleType).to.deep.equal("ordinal");
+    expect(rendered.props().xScaleType).to.equal('linear');
+    expect(rendered.props().yScaleType).to.deep.equal('ordinal');
   });
 
-  it("infers domain from Component.getDomain", () => {
+  it('infers domain from Component.getDomain', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const wrapped = mount(<XYChartWithCustomDomain {...props} />);
     const rendered = wrapped.find(ChartWithCustomDomain);
@@ -349,37 +349,37 @@ describe("resolveXYScales", () => {
     expect(rendered.props().yDomain).to.deep.equal(customDomain.yDomain);
   });
 
-  it("infers domain from data", () => {
+  it('infers domain from data', () => {
     const props = {
       width,
       height,
-      data: [[12, "a"], [18, "b"], [22, "c"]],
+      data: [[12, 'a'], [18, 'b'], [22, 'c']],
       x: d => d[0],
       y: d => d[1],
-      xScaleType: "linear",
-      yScaleType: "ordinal",
+      xScaleType: 'linear',
+      yScaleType: 'ordinal',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const wrapped = mount(<XYChart {...props} />);
     const rendered = wrapped.find(Chart);
 
     expect(rendered.props().xDomain).to.deep.equal([12, 22]);
-    expect(rendered.props().yDomain).to.deep.equal(["a", "b", "c"]);
+    expect(rendered.props().yDomain).to.deep.equal(['a', 'b', 'c']);
   });
 
-  it("infers domain from children getDomain", () => {
+  it('infers domain from children getDomain', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const tree = (
       <XYContainerChart {...props}>
@@ -392,16 +392,16 @@ describe("resolveXYScales", () => {
     expect(rendered.props().yDomain).to.deep.equal(customDomain.yDomain);
   });
 
-  it("infers domain from children data", () => {
+  it('infers domain from children data', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const tree = (
       <XYContainerChart {...props}>
@@ -416,18 +416,18 @@ describe("resolveXYScales", () => {
     expect(rendered.props().yDomain).to.deep.equal([0, 5]);
   });
 
-  it("x and y domain includes 0 given inferred domain from children data", () => {
+  it('x and y domain includes 0 given inferred domain from children data', () => {
     const props = {
       width,
       height,
       includeXZero: true,
       includeYZero: true,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
     const tree = (
       <XYContainerChart {...props}>
@@ -442,14 +442,14 @@ describe("resolveXYScales", () => {
     expect(rendered.props().yDomain).to.deep.equal([0, 14]);
   });
 
-  it("infers margin from Component.getMargin", () => {
+  it('infers margin from Component.getMargin', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       xDomain: [-50, 50],
-      yDomain: [-100, 100]
+      yDomain: [-100, 100],
     };
     const wrapped = mount(<XYChartWithCustomMargin {...props} />);
     const rendered = wrapped.find(ChartWithCustomMargin);
@@ -459,14 +459,14 @@ describe("resolveXYScales", () => {
     expect(rendered.props().marginRight).to.equal(customMargin.marginRight);
   });
 
-  it("infers margin from children getMargin", () => {
+  it('infers margin from children getMargin', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       xDomain: [-50, 50],
-      yDomain: [-100, 100]
+      yDomain: [-100, 100],
     };
     const tree = (
       <XYContainerChart {...props}>
@@ -481,14 +481,14 @@ describe("resolveXYScales", () => {
     expect(rendered.props().marginRight).to.equal(customMargin.marginRight);
   });
 
-  it("infers margin from children margin props", () => {
+  it('infers margin from children margin props', () => {
     const props = {
       width,
       height,
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       xDomain: [-50, 50],
-      yDomain: [-100, 100]
+      yDomain: [-100, 100],
     };
     const tree = (
       <XYContainerChart {...props}>
@@ -504,12 +504,12 @@ describe("resolveXYScales", () => {
     expect(rendered.props().marginRight).to.equal(50);
   });
 
-  it("infers scaleType & domain from data, margin from getMargin", () => {
+  it('infers scaleType & domain from data, margin from getMargin', () => {
     const containerProps = { width, height };
     const chartProps = {
-      data: [[12, "a"], [18, "b"], [22, "c"]],
+      data: [[12, 'a'], [18, 'b'], [22, 'c']],
       x: d => d[0],
-      y: d => d[1]
+      y: d => d[1],
     };
     const tree = (
       <XYContainerChart {...containerProps}>
@@ -523,35 +523,31 @@ describe("resolveXYScales", () => {
     expect(rendered.props().marginBottom).to.equal(customMargin.marginBottom);
     expect(rendered.props().marginLeft).to.equal(customMargin.marginLeft);
     expect(rendered.props().marginRight).to.equal(customMargin.marginRight);
-    expect(rendered.props().xScaleType).to.equal("linear");
-    expect(rendered.props().yScaleType).to.equal("ordinal");
+    expect(rendered.props().xScaleType).to.equal('linear');
+    expect(rendered.props().yScaleType).to.equal('ordinal');
     expect(rendered.props().xDomain).to.deep.equal([12, 22]);
-    expect(rendered.props().yDomain).to.deep.equal(["a", "b", "c"]);
+    expect(rendered.props().yDomain).to.deep.equal(['a', 'b', 'c']);
   });
 
-  it("inverts the scale domain if `invertScale` option is true", () => {
+  it('inverts the scale domain if `invertScale` option is true', () => {
     const props = {
       width,
       height,
       xDomain: [-3, 3],
       yDomain: [0, 10],
-      xScaleType: "linear",
-      yScaleType: "linear",
+      xScaleType: 'linear',
+      yScaleType: 'linear',
       marginTop: 11,
       marginBottom: 22,
       marginLeft: 33,
-      marginRight: 44
+      marginRight: 44,
     };
 
-    const invertXChart = mount(<XYChart {...props} invertXScale />).find(
-      Chart
-    );
+    const invertXChart = mount(<XYChart {...props} invertXScale />).find(Chart);
     expect(invertXChart.props().xDomain).to.deep.equal([3, -3]);
     expect(invertXChart.props().yDomain).to.deep.equal([0, 10]);
 
-    const invertYChart = mount(<XYChart {...props} invertYScale />).find(
-      Chart
-    );
+    const invertYChart = mount(<XYChart {...props} invertYScale />).find(Chart);
     expect(invertYChart.props().xDomain).to.deep.equal([-3, 3]);
     expect(invertYChart.props().yDomain).to.deep.equal([10, 0]);
   });

--- a/tests/jsdom/spec/resolveXYScales.spec.js
+++ b/tests/jsdom/spec/resolveXYScales.spec.js
@@ -1,19 +1,12 @@
-import _ from 'lodash';
 import React from 'react';
-import * as d3 from 'd3';
+import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { expect } from 'chai';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { isValidScale } from '../../../src/utils/Scale';
 import { innerRangeX, innerRangeY } from '../../../src/utils/Margin';
 
 import resolveXYScales from '../../../src/utils/resolveXYScales';
-
-class NotImplementedError extends Error {
-  constructor(message = 'Not Implemented Yet') {
-    super(message);
-  }
-}
 
 function expectRefAndDeepEqual(a, b) {
   expect(a).to.equal(b);
@@ -55,8 +48,7 @@ function expectXYScaledComponent(
     expect(renderedScale[k].domain()).to.deep.equal(domain[k]);
     if (scaleType[k] === 'ordinal')
       expect(renderedScale[k].range()).to.deep.equal(
-        d3
-          .scaleOrdinal()
+        scaleOrdinal()
           .domain(domain[k])
           .rangePoints(range[k])
           .range(),
@@ -89,8 +81,7 @@ function expectXYScaledComponentEnzyme(
     expect(renderedScale[k].domain()).to.deep.equal(domain[k]);
     if (scaleType[k] === 'ordinal')
       expect(renderedScale[k].range()).to.deep.equal(
-        d3
-          .scaleOrdinal()
+        scaleOrdinal()
           .domain(domain[k])
           .rangePoints(range[k])
           .range(),
@@ -184,12 +175,10 @@ describe('resolveXYScales', () => {
 
   it('passes XY scales and margins through if both are provided', () => {
     const props = {
-      xScale: d3
-        .scaleLinear()
+      xScale: scaleLinear()
         .domain([-1, 1])
         .range([0, 400]),
-      yScale: d3
-        .scaleLinear()
+      yScale: scaleLinear()
         .domain([-2, 2])
         .range([10, 300]),
       marginTop: 11,

--- a/tests/jsdom/spec/utils.Axis.spec.js
+++ b/tests/jsdom/spec/utils.Axis.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as d3 from 'd3';
+import { scaleLinear, scalePoint } from 'd3-scale';
 import _ from 'lodash';
 import {
   getAxisChildProps,
@@ -11,8 +11,8 @@ describe('Axis utils', () => {
     const axisProps = {
       width: 400,
       height: 250,
-      xScale: d3.scaleLinear(),
-      yScale: d3.scaleLinear(),
+      xScale: scaleLinear(),
+      yScale: scaleLinear(),
       spacingTop: 10,
       spacingBottom: 10,
       spacingLeft: 10,
@@ -174,8 +174,7 @@ describe('Axis utils', () => {
         clientY: 0,
       };
 
-      const scale = d3
-        .scalePoint()
+      const scale = scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]);
 
@@ -204,8 +203,7 @@ describe('Axis utils', () => {
         clientY: 50,
       };
 
-      const scale = d3
-        .scalePoint()
+      const scale = scalePoint()
         .domain(['a', 'b', 'c'])
         .range([0, 100]);
 

--- a/tests/jsdom/spec/utils.Data.spec.js
+++ b/tests/jsdom/spec/utils.Data.spec.js
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { mount } from "enzyme";
-import _ from "lodash";
-import React from "react";
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import _ from 'lodash';
+import React from 'react';
 import {
   combineDomains,
   datasetsFromPropsOrDescendants,
@@ -10,53 +10,53 @@ import {
   inferDatasetsType,
   inferDataType,
   isValidDomain,
-  makeAccessor
-} from "../../../src/utils/Data";
+  makeAccessor,
+} from '../../../src/utils/Data';
 
 const notImplemented = () => {
-  console.log("* * * TEST NOT YET IMPLEMENTED * * *");
-  throw new Error("not implemented");
+  console.log('* * * TEST NOT YET IMPLEMENTED * * *');
+  throw new Error('not implemented');
 };
 
-describe("Data utils", () => {
-  describe("makeAccessor", () => {
-    it("passes existing accessor functions through", () => {
+describe('Data utils', () => {
+  describe('makeAccessor', () => {
+    it('passes existing accessor functions through', () => {
       const getter = d => d + 1;
       expect(makeAccessor(getter)).to.equal(getter);
     });
 
-    it("returns identity function given null or undefined", () => {
+    it('returns identity function given null or undefined', () => {
       const d = { x: 6 };
       expect(makeAccessor(undefined)(d)).to.equal(d);
       expect(makeAccessor(null)(d)).to.equal(d);
     });
 
-    it("deeply retrieves object values given array indices and/or key strings", () => {
-      const d = [{ x: [{ y: "z" }] }];
+    it('deeply retrieves object values given array indices and/or key strings', () => {
+      const d = [{ x: [{ y: 'z' }] }];
       expect(makeAccessor(0)(d)).to.equal(d[0]);
-      expect(makeAccessor("0.x")(d)).to.equal(d[0].x);
-      expect(makeAccessor("0.x.0.y")(d)).to.equal("z");
-      expect(makeAccessor("x.0.y")(d[0])).to.equal("z");
+      expect(makeAccessor('0.x')(d)).to.equal(d[0].x);
+      expect(makeAccessor('0.x.0.y')(d)).to.equal('z');
+      expect(makeAccessor('x.0.y')(d[0])).to.equal('z');
     });
   });
 
-  describe("datasetsFromPropsOrDescendants", () => {
-    it("returns props.datasets", () => {
+  describe('datasetsFromPropsOrDescendants', () => {
+    it('returns props.datasets', () => {
       const props = { datasets: [[1]] };
       const datasets = datasetsFromPropsOrDescendants(props);
       expect(datasets).to.equal(props.datasets);
       expect(datasets).to.deep.equal(props.datasets);
     });
 
-    it("returns props.data wrapped in an array", () => {
+    it('returns props.data wrapped in an array', () => {
       const props = { data: [2] };
       const datasets = datasetsFromPropsOrDescendants(props);
-      expect(datasets).to.be.an("array");
+      expect(datasets).to.be.an('array');
       expect(datasets[0]).to.equal(props.data);
       expect(datasets[0]).to.deep.equal(props.data);
     });
 
-    it("traverses children and combines their props.data & props.datasets", () => {
+    it('traverses children and combines their props.data & props.datasets', () => {
       class TestComponent extends React.Component {
         render() {
           return <div>{this.props.children}</div>;
@@ -77,214 +77,214 @@ describe("Data utils", () => {
 
       const rendered = mount(tree);
       const datasets = datasetsFromPropsOrDescendants(rendered.props());
-      expect(datasets).to.be.an("array");
+      expect(datasets).to.be.an('array');
       expect(datasets).to.deep.equal([[0, 1], [2, 3], [4, 5], [6, 7]]);
     });
   });
 
-  describe("inferDataType", () => {
-    it("returns `number` for dataset with all numbers", () => {
-      expect(inferDataType([-1, 0, 1.2, 4.5])).to.equal("number");
+  describe('inferDataType', () => {
+    it('returns `number` for dataset with all numbers', () => {
+      expect(inferDataType([-1, 0, 1.2, 4.5])).to.equal('number');
     });
 
-    it("returns `time` for dataset with all Dates", () => {
+    it('returns `time` for dataset with all Dates', () => {
       expect(inferDataType([new Date(), new Date(2003, 2, 4)])).to.equal(
-        "time"
+        'time',
       );
     });
 
-    it("returns `categorical` for dataset with all strings", () => {
-      expect(inferDataType(["a", "b", "c"])).to.equal("categorical");
+    it('returns `categorical` for dataset with all strings', () => {
+      expect(inferDataType(['a', 'b', 'c'])).to.equal('categorical');
     });
 
-    it("returns `categorical` for mixed types", () => {
-      expect(inferDataType([42, new Date()])).to.equal("categorical");
+    it('returns `categorical` for mixed types', () => {
+      expect(inferDataType([42, new Date()])).to.equal('categorical');
     });
 
-    it("takes an accessor function for getting the data points", () => {
+    it('takes an accessor function for getting the data points', () => {
       const getD = d => d.a;
-      expect(inferDataType([{ a: 1 }, { a: 1.3 }], getD)).to.equal("number");
+      expect(inferDataType([{ a: 1 }, { a: 1.3 }], getD)).to.equal('number');
       expect(
-        inferDataType([{ a: new Date() }, { a: new Date() }], getD)
-      ).to.equal("time");
-      expect(inferDataType([{ a: "b" }, { a: "c" }], getD)).to.equal(
-        "categorical"
+        inferDataType([{ a: new Date() }, { a: new Date() }], getD),
+      ).to.equal('time');
+      expect(inferDataType([{ a: 'b' }, { a: 'c' }], getD)).to.equal(
+        'categorical',
       );
     });
   });
 
-  describe("inferDatasetsType", () => {
-    it("returns same as inferDataType if all datasets are same type", () => {
-      expect(inferDatasetsType([[-1, 0], [1.2, 4.5]])).to.equal("number");
+  describe('inferDatasetsType', () => {
+    it('returns same as inferDataType if all datasets are same type', () => {
+      expect(inferDatasetsType([[-1, 0], [1.2, 4.5]])).to.equal('number');
       expect(
-        inferDatasetsType([[new Date()], [new Date(2003, 2, 4)]])
-      ).to.equal("time");
-      expect(inferDatasetsType([["a"], ["b", "c"]])).to.equal("categorical");
-      expect(inferDatasetsType([[42, new Date()]])).to.equal("categorical");
+        inferDatasetsType([[new Date()], [new Date(2003, 2, 4)]]),
+      ).to.equal('time');
+      expect(inferDatasetsType([['a'], ['b', 'c']])).to.equal('categorical');
+      expect(inferDatasetsType([[42, new Date()]])).to.equal('categorical');
 
       const getD = d => d.a;
       expect(inferDatasetsType([[{ a: 1 }, { a: 1.3 }]], getD)).to.equal(
-        "number"
+        'number',
       );
       expect(
-        inferDatasetsType([[{ a: new Date() }, { a: new Date() }]], getD)
-      ).to.equal("time");
-      expect(inferDatasetsType([[{ a: "b" }, { a: "c" }]], getD)).to.equal(
-        "categorical"
+        inferDatasetsType([[{ a: new Date() }, { a: new Date() }]], getD),
+      ).to.equal('time');
+      expect(inferDatasetsType([[{ a: 'b' }, { a: 'c' }]], getD)).to.equal(
+        'categorical',
       );
     });
 
-    it("returns `categorical` if datasets are mixed types", () => {
-      expect(inferDatasetsType([[7], [new Date()]])).to.equal("categorical");
+    it('returns `categorical` if datasets are mixed types', () => {
+      expect(inferDatasetsType([[7], [new Date()]])).to.equal('categorical');
     });
   });
 
-  describe("domainFromData", () => {
+  describe('domainFromData', () => {
     const numberData = [2, 4, 6, -2, 0];
     const timeData = [
       new Date(2006, 1, 1),
       new Date(2013, 1, 1),
-      new Date(2008, 1, 1)
+      new Date(2008, 1, 1),
     ];
-    const categoricalData = ["a", "b", "c"];
+    const categoricalData = ['a', 'b', 'c'];
 
-    it("determines domain from data when type is provided", () => {
-      const numberDomain = domainFromData(numberData, _.identity, "number");
+    it('determines domain from data when type is provided', () => {
+      const numberDomain = domainFromData(numberData, _.identity, 'number');
       expect(numberDomain).to.deep.equal([-2, 6]);
-      const timeDomain = domainFromData(timeData, _.identity, "time");
+      const timeDomain = domainFromData(timeData, _.identity, 'time');
       expect(timeDomain).to.deep.equal([
         new Date(2006, 1, 1),
-        new Date(2013, 1, 1)
+        new Date(2013, 1, 1),
       ]);
       const categoricalDomain = domainFromData(
         numberData,
         _.identity,
-        "categorical"
+        'categorical',
       );
       expect(categoricalDomain).to.deep.equal(numberData);
     });
 
-    it("infers accessor & type when not provided", () => {
+    it('infers accessor & type when not provided', () => {
       const numberDomain = domainFromData(numberData);
       expect(numberDomain).to.deep.equal([-2, 6]);
       const timeDomain = domainFromData(timeData);
       expect(timeDomain).to.deep.equal([
         new Date(2006, 1, 1),
-        new Date(2013, 1, 1)
+        new Date(2013, 1, 1),
       ]);
       const categoricalDomain = domainFromData(categoricalData);
       expect(categoricalDomain).to.deep.equal(categoricalData);
     });
   });
 
-  describe("domainFromDatasets", () => {
+  describe('domainFromDatasets', () => {
     const numberDatasets = [[8, 7], [4, 5], [3, 1]];
     const timeDatasets = [
-      [new Date("2007-03-12"), new Date("2002-03-12")],
-      [new Date("2009-01-09"), new Date("2004-04-25")]
+      [new Date('2007-03-12'), new Date('2002-03-12')],
+      [new Date('2009-01-09'), new Date('2004-04-25')],
     ];
-    const categoricalDatasets = [["x", "z"], ["y", "z"]];
+    const categoricalDatasets = [['x', 'z'], ['y', 'z']];
 
-    it("determines domain from datasets when accessor & type are provided", () => {
+    it('determines domain from datasets when accessor & type are provided', () => {
       const numberDomain = domainFromDatasets(
         numberDatasets,
         _.identity,
-        "number"
+        'number',
       );
-      const timeDomain = domainFromDatasets(timeDatasets, _.identity, "time");
+      const timeDomain = domainFromDatasets(timeDatasets, _.identity, 'time');
       const categoricalDomain = domainFromDatasets(
         categoricalDatasets,
         _.identity,
-        "categorical"
+        'categorical',
       );
 
       expect(numberDomain).to.deep.equal([1, 8]);
       expect(timeDomain).to.deep.equal([
-        new Date("2002-03-12"),
-        new Date("2009-01-09")
+        new Date('2002-03-12'),
+        new Date('2009-01-09'),
       ]);
-      expect(categoricalDomain).to.deep.equal(["x", "z", "y"]);
+      expect(categoricalDomain).to.deep.equal(['x', 'z', 'y']);
     });
 
-    it("infers accessor & type when not provided", () => {
+    it('infers accessor & type when not provided', () => {
       const numberDomain = domainFromDatasets(numberDatasets);
       const timeDomain = domainFromDatasets(timeDatasets);
       const categoricalDomain = domainFromDatasets(categoricalDatasets);
 
       expect(numberDomain).to.deep.equal([1, 8]);
       expect(timeDomain).to.deep.equal([
-        new Date("2002-03-12"),
-        new Date("2009-01-09")
+        new Date('2002-03-12'),
+        new Date('2009-01-09'),
       ]);
-      expect(categoricalDomain).to.deep.equal(["x", "z", "y"]);
+      expect(categoricalDomain).to.deep.equal(['x', 'z', 'y']);
     });
   });
 
-  describe("combineDomains", () => {
-    it("returns extent of domains for number-type data", () => {
+  describe('combineDomains', () => {
+    it('returns extent of domains for number-type data', () => {
       const domains = [[0, 3], [2, 9], [-2, 4]];
-      expect(combineDomains(domains, "number")).to.deep.equal([-2, 9]);
+      expect(combineDomains(domains, 'number')).to.deep.equal([-2, 9]);
     });
 
-    it("returns extent of domains for time-type data", () => {
+    it('returns extent of domains for time-type data', () => {
       const domains = [
         [new Date(2004, 1, 1), new Date(2008, 1, 1)],
-        [new Date(2006, 1, 1), new Date(2010, 1, 1)]
+        [new Date(2006, 1, 1), new Date(2010, 1, 1)],
       ];
-      expect(combineDomains(domains, "time")).to.deep.equal([
+      expect(combineDomains(domains, 'time')).to.deep.equal([
         new Date(2004, 1, 1),
-        new Date(2010, 1, 1)
+        new Date(2010, 1, 1),
       ]);
     });
 
-    it("returns all unique domain values for categorical-type data", () => {
-      const domains = [["a", "b", "c"], ["b", "d", "c", "e"]];
-      expect(combineDomains(domains, "categorical")).to.deep.equal([
-        "a",
-        "b",
-        "c",
-        "d",
-        "e"
+    it('returns all unique domain values for categorical-type data', () => {
+      const domains = [['a', 'b', 'c'], ['b', 'd', 'c', 'e']];
+      expect(combineDomains(domains, 'categorical')).to.deep.equal([
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
       ]);
     });
   });
 
-  describe("isValidDomain", () => {
-    it("returns false for non-arrays and empty arrays", () => {
+  describe('isValidDomain', () => {
+    it('returns false for non-arrays and empty arrays', () => {
       expect(isValidDomain(4)).to.equal(false);
-      expect(isValidDomain("abc")).to.equal(false);
+      expect(isValidDomain('abc')).to.equal(false);
       expect(isValidDomain([])).to.equal(false);
     });
 
-    it("returns true for any array with items if type is categorical", () => {
+    it('returns true for any array with items if type is categorical', () => {
       expect(isValidDomain([4])).to.equal(true);
-      expect(isValidDomain([4], "categorical")).to.equal(true);
-      expect(isValidDomain(["abc", "def", "ghi"])).to.equal(true);
-      expect(isValidDomain(["abc", "def", "ghi"], "categorical")).to.equal(
-        true
+      expect(isValidDomain([4], 'categorical')).to.equal(true);
+      expect(isValidDomain(['abc', 'def', 'ghi'])).to.equal(true);
+      expect(isValidDomain(['abc', 'def', 'ghi'], 'categorical')).to.equal(
+        true,
       );
       expect(isValidDomain([new Date(), new Date()])).to.equal(true);
-      expect(isValidDomain([new Date(), new Date()], "categorical")).to.equal(
-        true
+      expect(isValidDomain([new Date(), new Date()], 'categorical')).to.equal(
+        true,
       );
     });
 
-    it("returns true for 2-item number arrays if type is number", () => {
-      expect(isValidDomain([4, 5], "number")).to.equal(true);
-      expect(isValidDomain([4], "number")).to.equal(false);
-      expect(isValidDomain([4, 5, 6], "number")).to.equal(false);
-      expect(isValidDomain([new Date(), new Date()], "number")).to.equal(false);
-      expect(isValidDomain(["abc", "def"], "number")).to.equal(false);
+    it('returns true for 2-item number arrays if type is number', () => {
+      expect(isValidDomain([4, 5], 'number')).to.equal(true);
+      expect(isValidDomain([4], 'number')).to.equal(false);
+      expect(isValidDomain([4, 5, 6], 'number')).to.equal(false);
+      expect(isValidDomain([new Date(), new Date()], 'number')).to.equal(false);
+      expect(isValidDomain(['abc', 'def'], 'number')).to.equal(false);
     });
 
-    it("returns true for 2-item date arrays if type is time", () => {
-      expect(isValidDomain([new Date(), new Date()], "time")).to.equal(true);
-      expect(isValidDomain([new Date()], "time")).to.equal(false);
+    it('returns true for 2-item date arrays if type is time', () => {
+      expect(isValidDomain([new Date(), new Date()], 'time')).to.equal(true);
+      expect(isValidDomain([new Date()], 'time')).to.equal(false);
       expect(
-        isValidDomain([new Date(), new Date(), new Date()], "time")
+        isValidDomain([new Date(), new Date(), new Date()], 'time'),
       ).to.equal(false);
-      expect(isValidDomain([4, 5], "time")).to.equal(false);
-      expect(isValidDomain(["abc", "def"], "time")).to.equal(false);
+      expect(isValidDomain([4, 5], 'time')).to.equal(false);
+      expect(isValidDomain(['abc', 'def'], 'time')).to.equal(false);
     });
   });
 });

--- a/tests/jsdom/spec/utils.Label.spec.js
+++ b/tests/jsdom/spec/utils.Label.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as d3 from 'd3';
+import { scaleLinear } from 'd3-scale';
 import {
   checkLabelsDistinct,
   checkRangesOverlap,
@@ -77,7 +77,7 @@ describe('Label utils', () => {
   });
 
   it('getLabelXRange', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelXRange(scale, label)).to.eql([
@@ -87,7 +87,7 @@ describe('Label utils', () => {
   });
 
   it('getLabelYRange', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelYRange(scale, label)).to.eql([
@@ -97,21 +97,21 @@ describe('Label utils', () => {
   });
 
   it('getLabelXOverhang', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelXOverhang(scale, label)).to.eql([10, 10]);
   });
 
   it('getLabelYOverhang', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelYOverhang(scale, label)).to.eql([7, 7]);
   });
 
   it('getLabelsXOverhang', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const labels = [
       { value: -20, text: '-20', height: 14, width: 20.234375 },
       { value: -15, text: '-15', height: 14, width: 20.234375 },
@@ -125,7 +125,7 @@ describe('Label utils', () => {
   });
 
   it('getLabelsYOverhang', () => {
-    const scale = d3.scaleLinear().domain([-30, 30]);
+    const scale = scaleLinear().domain([-30, 30]);
     const labels = [
       { value: -20, text: '-20', height: 14, width: 20.234375 },
       { value: -15, text: '-15', height: 14, width: 20.234375 },

--- a/tests/jsdom/spec/utils.Label.spec.js
+++ b/tests/jsdom/spec/utils.Label.spec.js
@@ -1,5 +1,5 @@
-import { expect } from "chai";
-import * as d3 from "d3";
+import { expect } from 'chai';
+import * as d3 from 'd3';
 import {
   checkLabelsDistinct,
   checkRangesOverlap,
@@ -10,18 +10,18 @@ import {
   getLabelXRange,
   getLabelYOverhang,
   getLabelYRange,
-  makeLabelFormatters
-} from "../../../src/utils/Label";
+  makeLabelFormatters,
+} from '../../../src/utils/Label';
 
-describe("Label utils", () => {
-  it("checkLabelsDistinct", () => {
+describe('Label utils', () => {
+  it('checkLabelsDistinct', () => {
     const labels = [
-      { value: -20, text: "-20", height: 14, width: 20.234375 },
-      { value: -15, text: "-15", height: 14, width: 20.234375 },
-      { value: -10, text: "-10", height: 14, width: 20.234375 },
-      { value: -5, text: "-5", height: 14, width: 12.4482421875 },
-      { value: 0, text: "0", height: 14, width: 7.7861328125 },
-      { value: 5, text: "5", height: 14, width: 7.7861328125 }
+      { value: -20, text: '-20', height: 14, width: 20.234375 },
+      { value: -15, text: '-15', height: 14, width: 20.234375 },
+      { value: -10, text: '-10', height: 14, width: 20.234375 },
+      { value: -5, text: '-5', height: 14, width: 12.4482421875 },
+      { value: 0, text: '0', height: 14, width: 7.7861328125 },
+      { value: 5, text: '5', height: 14, width: 7.7861328125 },
     ];
 
     expect(checkLabelsDistinct(labels)).to.equal(true);
@@ -31,7 +31,7 @@ describe("Label utils", () => {
     expect(checkLabelsDistinct(labels)).to.equal(false);
   });
 
-  it("checkRangesOverlap", () => {
+  it('checkRangesOverlap', () => {
     const arr1 = [5, 10];
     const arr2 = [11, 15];
     const arr3 = [8, 12];
@@ -41,32 +41,32 @@ describe("Label utils", () => {
     expect(checkRangesOverlap(arr2, arr3)).to.equal(true);
   });
 
-  it("makeLabelFormatters", () => {
+  it('makeLabelFormatters', () => {
     const formatStrs = [
-      "0.[00]a",
-      "0,0",
-      "0.[0]",
-      "0.[00]",
-      "0.[0000]",
-      "0.[000000]"
+      '0.[00]a',
+      '0,0',
+      '0.[0]',
+      '0.[00]',
+      '0.[0000]',
+      '0.[000000]',
     ];
-    const scaleType = "linear";
+    const scaleType = 'linear';
 
     const results = makeLabelFormatters(formatStrs, scaleType);
     expect(results).to.have.lengthOf(6);
     results.forEach(r => {
-      expect(r).is.a("function");
+      expect(r).is.a('function');
     });
   });
 
-  it("countRangeOverlaps", () => {
+  it('countRangeOverlaps', () => {
     const ranges = [
       [-10.1171875, 10.1171875],
       [27.3828125, 47.6171875],
       [64.8828125, 85.1171875],
       [106.27587890625, 118.72412109375],
       [146.10693359375, 153.89306640625],
-      [183.60693359375, 191.39306640625]
+      [183.60693359375, 191.39306640625],
     ];
 
     expect(countRangeOverlaps(ranges)).to.equal(0);
@@ -76,63 +76,63 @@ describe("Label utils", () => {
     expect(countRangeOverlaps(ranges)).to.equal(1);
   });
 
-  it("getLabelXRange", () => {
+  it('getLabelXRange', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
-    const label = { value: -20, text: "-20", height: 14, width: 20.234375 };
+    const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelXRange(scale, label)).to.eql([
       -9.950520833333334,
-      10.283854166666666
+      10.283854166666666,
     ]);
   });
 
-  it("getLabelYRange", () => {
+  it('getLabelYRange', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
-    const label = { value: -20, text: "-20", height: 14, width: 20.234375 };
+    const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelYRange(scale, label)).to.eql([
       -6.833333333333333,
-      7.166666666666667
+      7.166666666666667,
     ]);
   });
 
-  it("getLabelXOverhang", () => {
+  it('getLabelXOverhang', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
-    const label = { value: -20, text: "-20", height: 14, width: 20.234375 };
+    const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelXOverhang(scale, label)).to.eql([10, 10]);
   });
 
-  it("getLabelYOverhang", () => {
+  it('getLabelYOverhang', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
-    const label = { value: -20, text: "-20", height: 14, width: 20.234375 };
+    const label = { value: -20, text: '-20', height: 14, width: 20.234375 };
 
     expect(getLabelYOverhang(scale, label)).to.eql([7, 7]);
   });
 
-  it("getLabelsXOverhang", () => {
+  it('getLabelsXOverhang', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
     const labels = [
-      { value: -20, text: "-20", height: 14, width: 20.234375 },
-      { value: -15, text: "-15", height: 14, width: 20.234375 },
-      { value: -10, text: "-10", height: 14, width: 20.234375 },
-      { value: -5, text: "-5", height: 14, width: 12.4482421875 },
-      { value: 0, text: "0", height: 14, width: 7.7861328125 },
-      { value: 5, text: "5", height: 14, width: 7.7861328125 }
+      { value: -20, text: '-20', height: 14, width: 20.234375 },
+      { value: -15, text: '-15', height: 14, width: 20.234375 },
+      { value: -10, text: '-10', height: 14, width: 20.234375 },
+      { value: -5, text: '-5', height: 14, width: 12.4482421875 },
+      { value: 0, text: '0', height: 14, width: 7.7861328125 },
+      { value: 5, text: '5', height: 14, width: 7.7861328125 },
     ];
 
     expect(getLabelsXOverhang(scale, labels)).to.eql([10, 10]);
   });
 
-  it("getLabelsYOverhang", () => {
+  it('getLabelsYOverhang', () => {
     const scale = d3.scaleLinear().domain([-30, 30]);
     const labels = [
-      { value: -20, text: "-20", height: 14, width: 20.234375 },
-      { value: -15, text: "-15", height: 14, width: 20.234375 },
-      { value: -10, text: "-10", height: 14, width: 20.234375 },
-      { value: -5, text: "-5", height: 14, width: 12.4482421875 },
-      { value: 0, text: "0", height: 14, width: 7.7861328125 },
-      { value: 5, text: "5", height: 14, width: 7.7861328125 }
+      { value: -20, text: '-20', height: 14, width: 20.234375 },
+      { value: -15, text: '-15', height: 14, width: 20.234375 },
+      { value: -10, text: '-10', height: 14, width: 20.234375 },
+      { value: -5, text: '-5', height: 14, width: 12.4482421875 },
+      { value: 0, text: '0', height: 14, width: 7.7861328125 },
+      { value: 5, text: '5', height: 14, width: 7.7861328125 },
     ];
 
     expect(getLabelsYOverhang(scale, labels)).to.eql([7, 7]);

--- a/tests/jsdom/spec/utils.Margin.spec.js
+++ b/tests/jsdom/spec/utils.Margin.spec.js
@@ -1,16 +1,16 @@
-import { expect } from "chai";
+import { expect } from 'chai';
 import {
   innerHeight,
   innerRangeX,
   innerRangeY,
   innerWidth,
   prefixKeys,
-  sumMargins
-} from "../../../src/utils/Margin";
+  sumMargins,
+} from '../../../src/utils/Margin';
 
-describe("Scale utils", () => {
-  describe("innerWidth", () => {
-    it("returns inner width value, given outer width and a margin object", () => {
+describe('Scale utils', () => {
+  describe('innerWidth', () => {
+    it('returns inner width value, given outer width and a margin object', () => {
       expect(innerWidth(500)).to.equal(500);
       expect(innerWidth(500, {})).to.equal(500);
       expect(innerWidth(500, { top: 100, bottom: 50 })).to.equal(500);
@@ -19,8 +19,8 @@ describe("Scale utils", () => {
     });
   });
 
-  describe("innerHeight", () => {
-    it("returns inner height value, given outer height and a margin object", () => {
+  describe('innerHeight', () => {
+    it('returns inner height value, given outer height and a margin object', () => {
       expect(innerHeight(500)).to.equal(500);
       expect(innerHeight(500, {})).to.equal(500);
       expect(innerHeight(500, { left: 100, right: 50 })).to.equal(500);
@@ -29,69 +29,69 @@ describe("Scale utils", () => {
     });
   });
 
-  describe("innerRangeX", () => {
-    it("returns inner X-range array, given outer width and a margin object", () => {
+  describe('innerRangeX', () => {
+    it('returns inner X-range array, given outer width and a margin object', () => {
       expect(innerRangeX(500)).to.deep.equal([0, 500]);
       expect(innerRangeX(500, {})).to.deep.equal([0, 500]);
       expect(innerRangeX(500, { top: 100, bottom: 50 })).to.deep.equal([
         0,
-        500
+        500,
       ]);
       expect(innerRangeX(500, { left: 100, right: 50 })).to.deep.equal([
         100,
-        450
+        450,
       ]);
       expect(innerRangeX(10, { left: 100, right: 50 })).to.deep.equal([10, 10]);
       expect(innerRangeX(120, { left: 100, right: 50 })).to.deep.equal([
         100,
-        100
+        100,
       ]);
     });
   });
 
-  describe("innerRangeY", () => {
-    it("returns inner Y-range array, given outer width and a margin object", () => {
+  describe('innerRangeY', () => {
+    it('returns inner Y-range array, given outer width and a margin object', () => {
       expect(innerRangeY(500)).to.deep.equal([500, 0]);
       expect(innerRangeY(500, {})).to.deep.equal([500, 0]);
       expect(innerRangeY(500, { left: 100, right: 50 })).to.deep.equal([
         500,
-        0
+        0,
       ]);
       expect(innerRangeY(500, { top: 100, bottom: 50 })).to.deep.equal([
         450,
-        100
+        100,
       ]);
       expect(innerRangeY(10, { top: 100, bottom: 50 })).to.deep.equal([10, 10]);
       expect(innerRangeY(120, { top: 100, bottom: 50 })).to.deep.equal([
         100,
-        100
+        100,
       ]);
     });
   });
 
-  describe("prefixKeys", () => {
+  describe('prefixKeys', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const prefix = "woot";
+    const prefix = 'woot';
 
     expect(prefixKeys(obj, prefix)).to.eql({
       wootA: 1,
       wootB: 2,
-      wootC: 3
+      wootC: 3,
     });
   });
 
-  describe("sumMargins", () => {
+  describe('sumMargins', () => {
     const margins = [
       { marginBottom: 5, marginTop: 0, marginLeft: 0, marginRight: 0 },
       { marginTop: 0, marginBottom: 29, marginLeft: 0, marginRight: 0 },
-      { marginBottom: 17, marginLeft: 16, marginRight: 16, marginTop: 0 }
+      { marginBottom: 17, marginLeft: 16, marginRight: 16, marginTop: 0 },
     ];
-    const prefix = "margin";
+    const prefix = 'margin';
     expect(sumMargins(margins, prefix)).to.eql({
       marginTop: 0,
       marginBottom: 51,
       marginLeft: 16,
-      marginRight: 16
+      marginRight: 16,
     });
   });
 });

--- a/tests/jsdom/spec/utils.Scale.spec.js
+++ b/tests/jsdom/spec/utils.Scale.spec.js
@@ -1,7 +1,7 @@
-import _ from "lodash";
-import React from "react";
-import * as d3 from "d3";
-import { expect } from "chai";
+import _ from 'lodash';
+import React from 'react';
+import * as d3 from 'd3';
+import { expect } from 'chai';
 
 import {
   scaleTypeFromDataType,
@@ -10,98 +10,98 @@ import {
   initScale,
   isValidScale,
   invertPointScale,
-  indexOfClosestNumberInList
-} from "../../../src/utils/Scale";
+  indexOfClosestNumberInList,
+} from '../../../src/utils/Scale';
 
-describe("Scale utils", () => {
-  describe("scaleTypeFromDataType", () => {
-    it("returns scale types given data types", () => {
-      expect(scaleTypeFromDataType("number")).to.equal("linear");
-      expect(scaleTypeFromDataType("time")).to.equal("time");
-      expect(scaleTypeFromDataType("categorical")).to.equal("ordinal");
+describe('Scale utils', () => {
+  describe('scaleTypeFromDataType', () => {
+    it('returns scale types given data types', () => {
+      expect(scaleTypeFromDataType('number')).to.equal('linear');
+      expect(scaleTypeFromDataType('time')).to.equal('time');
+      expect(scaleTypeFromDataType('categorical')).to.equal('ordinal');
     });
 
-    it("returns `ordinal` for unknown data types", () => {
-      expect(scaleTypeFromDataType("chewbacca")).to.equal("ordinal");
-    });
-  });
-
-  describe("dataTypeFromScaleType", () => {
-    it("returns data types given scale types", () => {
-      expect(dataTypeFromScaleType("linear")).to.equal("number");
-      expect(dataTypeFromScaleType("log")).to.equal("number");
-      expect(dataTypeFromScaleType("pow")).to.equal("number");
-      expect(dataTypeFromScaleType("time")).to.equal("time");
-      expect(dataTypeFromScaleType("ordinal")).to.equal("categorical");
-    });
-
-    it("returns `categorical` for unknown scale types", () => {
-      expect(dataTypeFromScaleType("chewbacca")).to.equal("categorical");
+    it('returns `ordinal` for unknown data types', () => {
+      expect(scaleTypeFromDataType('chewbacca')).to.equal('ordinal');
     });
   });
 
-  describe("inferScaleType", () => {
-    it("infers the correct scale type, given a scale", () => {
-      expect(inferScaleType(d3.scaleLinear())).to.equal("linear");
-      expect(inferScaleType(d3.scaleTime())).to.equal("time");
-      expect(inferScaleType(d3.scaleOrdinal())).to.equal("ordinal");
-      expect(inferScaleType(d3.scaleLog())).to.equal("log");
-      expect(inferScaleType(d3.scalePow())).to.equal("pow");
+  describe('dataTypeFromScaleType', () => {
+    it('returns data types given scale types', () => {
+      expect(dataTypeFromScaleType('linear')).to.equal('number');
+      expect(dataTypeFromScaleType('log')).to.equal('number');
+      expect(dataTypeFromScaleType('pow')).to.equal('number');
+      expect(dataTypeFromScaleType('time')).to.equal('time');
+      expect(dataTypeFromScaleType('ordinal')).to.equal('categorical');
+    });
+
+    it('returns `categorical` for unknown scale types', () => {
+      expect(dataTypeFromScaleType('chewbacca')).to.equal('categorical');
     });
   });
 
-  describe("initScale", () => {
-    it("creates a scale of the correct type, given a scale type", () => {
-      const linearScale = initScale("linear")
+  describe('inferScaleType', () => {
+    it('infers the correct scale type, given a scale', () => {
+      expect(inferScaleType(d3.scaleLinear())).to.equal('linear');
+      expect(inferScaleType(d3.scaleTime())).to.equal('time');
+      expect(inferScaleType(d3.scaleOrdinal())).to.equal('ordinal');
+      expect(inferScaleType(d3.scaleLog())).to.equal('log');
+      expect(inferScaleType(d3.scalePow())).to.equal('pow');
+    });
+  });
+
+  describe('initScale', () => {
+    it('creates a scale of the correct type, given a scale type', () => {
+      const linearScale = initScale('linear')
         .domain([0, 1])
         .range([100, 200]);
-      expect(inferScaleType(linearScale)).to.equal("linear");
+      expect(inferScaleType(linearScale)).to.equal('linear');
       expect(linearScale(0.5)).to.equal(150);
 
-      expect(inferScaleType(initScale("time"))).to.equal("time");
-      expect(inferScaleType(initScale("ordinal"))).to.equal("ordinal");
-      expect(inferScaleType(initScale("log"))).to.equal("log");
-      expect(inferScaleType(initScale("pow"))).to.equal("pow");
+      expect(inferScaleType(initScale('time'))).to.equal('time');
+      expect(inferScaleType(initScale('ordinal'))).to.equal('ordinal');
+      expect(inferScaleType(initScale('log'))).to.equal('log');
+      expect(inferScaleType(initScale('pow'))).to.equal('pow');
     });
   });
 
-  describe("isValidScale", () => {
-    it("returns true for all known scale types", () => {
+  describe('isValidScale', () => {
+    it('returns true for all known scale types', () => {
       expect(isValidScale(d3.scaleLinear())).to.equal(true);
       expect(isValidScale(d3.scaleTime())).to.equal(true);
       expect(isValidScale(d3.scaleOrdinal())).to.equal(true);
       expect(isValidScale(d3.scaleLog())).to.equal(true);
       expect(isValidScale(d3.scalePow())).to.equal(true);
     });
-    it("returns false for non-scale things", () => {
+    it('returns false for non-scale things', () => {
       expect(isValidScale(9)).to.equal(false);
       expect(isValidScale(true)).to.equal(false);
       expect(isValidScale([4, 5])).to.equal(false);
       expect(isValidScale({ range: [0, 100], domain: [500, 1000] })).to.equal(
-        false
+        false,
       );
     });
   });
 
-  describe("indexOfClosestNumberInList", () => {
-    it("returns index of closest to the number in the array", () => {
+  describe('indexOfClosestNumberInList', () => {
+    it('returns index of closest to the number in the array', () => {
       expect(indexOfClosestNumberInList(1.5, [5, 4, 3, 2, 1])).to.equal(3);
       expect(indexOfClosestNumberInList(1.5, [1, 2, 3, 4, 5])).to.equal(0);
     });
   });
 
-  describe("invertPointScale", () => {
-    it("returns a valid value for given rangeValue", () => {
+  describe('invertPointScale', () => {
+    it('returns a valid value for given rangeValue', () => {
       const scale = d3
         .scalePoint()
-        .domain(["a", "b", "c", "d", "e"])
+        .domain(['a', 'b', 'c', 'd', 'e'])
         .range([0, 100]);
 
-      expect(invertPointScale(scale, 0)).to.equal("a");
-      expect(invertPointScale(scale, 26)).to.equal("b");
-      expect(invertPointScale(scale, 51)).to.equal("c");
-      expect(invertPointScale(scale, 76)).to.equal("d");
-      expect(invertPointScale(scale, 101)).to.equal("e");
+      expect(invertPointScale(scale, 0)).to.equal('a');
+      expect(invertPointScale(scale, 26)).to.equal('b');
+      expect(invertPointScale(scale, 51)).to.equal('c');
+      expect(invertPointScale(scale, 76)).to.equal('d');
+      expect(invertPointScale(scale, 101)).to.equal('e');
     });
   });
 });

--- a/tests/jsdom/spec/utils.Scale.spec.js
+++ b/tests/jsdom/spec/utils.Scale.spec.js
@@ -1,6 +1,12 @@
-import _ from 'lodash';
 import React from 'react';
-import * as d3 from 'd3';
+import {
+  scaleLinear,
+  scaleTime,
+  scaleOrdinal,
+  scaleLog,
+  scalePoint,
+  scalePow,
+} from 'd3-scale';
 import { expect } from 'chai';
 
 import {
@@ -42,11 +48,11 @@ describe('Scale utils', () => {
 
   describe('inferScaleType', () => {
     it('infers the correct scale type, given a scale', () => {
-      expect(inferScaleType(d3.scaleLinear())).to.equal('linear');
-      expect(inferScaleType(d3.scaleTime())).to.equal('time');
-      expect(inferScaleType(d3.scaleOrdinal())).to.equal('ordinal');
-      expect(inferScaleType(d3.scaleLog())).to.equal('log');
-      expect(inferScaleType(d3.scalePow())).to.equal('pow');
+      expect(inferScaleType(scaleLinear())).to.equal('linear');
+      expect(inferScaleType(scaleTime())).to.equal('time');
+      expect(inferScaleType(scaleOrdinal())).to.equal('ordinal');
+      expect(inferScaleType(scaleLog())).to.equal('log');
+      expect(inferScaleType(scalePow())).to.equal('pow');
     });
   });
 
@@ -67,11 +73,11 @@ describe('Scale utils', () => {
 
   describe('isValidScale', () => {
     it('returns true for all known scale types', () => {
-      expect(isValidScale(d3.scaleLinear())).to.equal(true);
-      expect(isValidScale(d3.scaleTime())).to.equal(true);
-      expect(isValidScale(d3.scaleOrdinal())).to.equal(true);
-      expect(isValidScale(d3.scaleLog())).to.equal(true);
-      expect(isValidScale(d3.scalePow())).to.equal(true);
+      expect(isValidScale(scaleLinear())).to.equal(true);
+      expect(isValidScale(scaleTime())).to.equal(true);
+      expect(isValidScale(scaleOrdinal())).to.equal(true);
+      expect(isValidScale(scaleLog())).to.equal(true);
+      expect(isValidScale(scalePow())).to.equal(true);
     });
     it('returns false for non-scale things', () => {
       expect(isValidScale(9)).to.equal(false);
@@ -92,8 +98,7 @@ describe('Scale utils', () => {
 
   describe('invertPointScale', () => {
     it('returns a valid value for given rangeValue', () => {
-      const scale = d3
-        .scalePoint()
+      const scale = scalePoint()
         .domain(['a', 'b', 'c', 'd', 'e'])
         .range([0, 100]);
 

--- a/tests/jsdom/spec/utils.measureText.spec.js
+++ b/tests/jsdom/spec/utils.measureText.spec.js
@@ -20,8 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { expect } from "chai";
-import measureText from "../../../src/utils/measureText";
+import { expect } from 'chai';
+import measureText from '../../../src/utils/measureText';
 
 class MockCtx {
   measureText() {
@@ -35,78 +35,78 @@ class MockCanvas {
   }
 }
 
-describe("measure-text", () => {
+describe('measure-text', () => {
   it(`should measure a single line of text provided a
       px font size and a unitless line height`, () => {
     const measurement = measureText({
-      text: "The quick brown fox jumps over the lazy dog",
-      fontFamily: "Helvetica Neue",
-      fontSize: "24px",
-      lineHeight: "1.2",
+      text: 'The quick brown fox jumps over the lazy dog',
+      fontFamily: 'Helvetica Neue',
+      fontSize: '24px',
+      lineHeight: '1.2',
       fontWeight: 400,
-      fontStyle: "normal",
-      canvas: new MockCanvas()
+      fontStyle: 'normal',
+      canvas: new MockCanvas(),
     });
 
-    expect(measurement).to.have.deep.nested.property("width.value", 42);
-    expect(measurement).to.have.deep.nested.property("height.value", 24 * 1.2);
-    expect(measurement).to.have.deep.nested.property("width.unit", "px");
-    expect(measurement).to.have.deep.nested.property("height.unit", "px");
+    expect(measurement).to.have.deep.nested.property('width.value', 42);
+    expect(measurement).to.have.deep.nested.property('height.value', 24 * 1.2);
+    expect(measurement).to.have.deep.nested.property('width.unit', 'px');
+    expect(measurement).to.have.deep.nested.property('height.unit', 'px');
   });
 
   it(`should measure multiline text provided a
       px font size and a unitless line height`, () => {
     const measurement = measureText({
       text: [
-        "The quick brown fox jumps over the lazy dog",
-        "The lazy fox jumps over the quick brown dog",
-        "The dog jumps over the quick, lazy brown fox"
+        'The quick brown fox jumps over the lazy dog',
+        'The lazy fox jumps over the quick brown dog',
+        'The dog jumps over the quick, lazy brown fox',
       ],
-      fontFamily: "Helvetica Neue",
-      fontSize: "24px",
-      lineHeight: "1.2",
-      fontWeight: "bold",
-      fontStyle: "italic",
-      canvas: new MockCanvas()
+      fontFamily: 'Helvetica Neue',
+      fontSize: '24px',
+      lineHeight: '1.2',
+      fontWeight: 'bold',
+      fontStyle: 'italic',
+      canvas: new MockCanvas(),
     });
-    expect(measurement).to.have.deep.nested.property("width.value", 42);
+    expect(measurement).to.have.deep.nested.property('width.value', 42);
     expect(measurement).to.have.deep.nested.property(
-      "height.value",
-      24 * 1.2 * 3
+      'height.value',
+      24 * 1.2 * 3,
     );
-    expect(measurement).to.have.deep.nested.property("width.unit", "px");
-    expect(measurement).to.have.deep.nested.property("height.unit", "px");
+    expect(measurement).to.have.deep.nested.property('width.unit', 'px');
+    expect(measurement).to.have.deep.nested.property('height.unit', 'px');
   });
 
   it(`should calculate height when provided a
       em font size and a unitless line height`, () => {
     const measurement = measureText({
-      text: "The quick brown fox jumps over the lazy dog",
-      fontFamily: "Georgia",
-      fontSize: "2em",
+      text: 'The quick brown fox jumps over the lazy dog',
+      fontFamily: 'Georgia',
+      fontSize: '2em',
       lineHeight: 1.3,
       fontWeight: 700,
-      fontStyle: "italic",
-      canvas: new MockCanvas()
+      fontStyle: 'italic',
+      canvas: new MockCanvas(),
     });
 
-    expect(measurement).to.have.deep.nested.property("height.value", 2 * 1.3);
-    expect(measurement).to.have.deep.nested.property("height.unit", "em");
+    expect(measurement).to.have.deep.nested.property('height.value', 2 * 1.3);
+    expect(measurement).to.have.deep.nested.property('height.unit', 'em');
   });
 
   it(`should calculate height when provided a
       line height with units`, () => {
     const measurement = measureText({
-      text: "The quick brown fox jumps over the lazy dog",
-      fontFamily: "Georgia",
-      fontSize: "30px",
-      lineHeight: "40px",
+      text: 'The quick brown fox jumps over the lazy dog',
+      fontFamily: 'Georgia',
+      fontSize: '30px',
+      lineHeight: '40px',
       fontWeight: 400,
-      fontStyle: "normal",
-      canvas: new MockCanvas()
+      fontStyle: 'normal',
+      canvas: new MockCanvas(),
     });
 
-    expect(measurement).to.have.deep.nested.property("height.value", 40);
-    expect(measurement).to.have.deep.nested.property("height.unit", "px");
+    expect(measurement).to.have.deep.nested.property('height.value', 40);
+    expect(measurement).to.have.deep.nested.property('height.unit', 'px');
   });
 });

--- a/tests/jsdom/utils.js
+++ b/tests/jsdom/utils.js
@@ -1,5 +1,5 @@
-import * as d3 from 'd3';
 import _ from 'lodash';
+import { scaleLinear, scalePoint } from 'd3-scale';
 import { expect } from 'chai';
 
 export function expectProps(el, expectedProps) {
@@ -12,16 +12,14 @@ export function expectProps(el, expectedProps) {
 export function testWithScales(scaleTypes, callback) {
   const testScales = {
     linear: {
-      scale: d3
-        .scaleLinear()
+      scale: scaleLinear()
         .domain([-3, 3])
         .range([20, 100]),
       testValues: [-1.4, 1.7, 2.8],
     },
     // time: {},
     ordinal: {
-      scale: d3
-        .scalePoint()
+      scale: scalePoint()
         .domain(['a', 'b', 'c', 'd', 'e'])
         .range([0, 100]),
       testValues: ['a', 'c', 'e'],

--- a/tests/jsdom/utils.js
+++ b/tests/jsdom/utils.js
@@ -1,6 +1,6 @@
-import * as d3 from "d3";
-import _ from "lodash";
-import { expect } from "chai";
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { expect } from 'chai';
 
 export function expectProps(el, expectedProps) {
   const props = el.props();
@@ -16,27 +16,27 @@ export function testWithScales(scaleTypes, callback) {
         .scaleLinear()
         .domain([-3, 3])
         .range([20, 100]),
-      testValues: [-1.4, 1.7, 2.8]
+      testValues: [-1.4, 1.7, 2.8],
     },
     // time: {},
     ordinal: {
       scale: d3
         .scalePoint()
-        .domain(["a", "b", "c", "d", "e"])
+        .domain(['a', 'b', 'c', 'd', 'e'])
         .range([0, 100]),
-      testValues: ["a", "c", "e"]
-    }
+      testValues: ['a', 'c', 'e'],
+    },
   };
 
   scaleTypes.forEach(scaleType => {
     if (!_.has(testScales, scaleType))
       throw new Error(
-        `${scaleType} is not a valid scaleType for testWithScales`
+        `${scaleType} is not a valid scaleType for testWithScales`,
       );
   });
 
   const scalesToTest = _.compact(
-    scaleTypes.map(scaleType => testScales[scaleType])
+    scaleTypes.map(scaleType => testScales[scaleType]),
   );
   scalesToTest.forEach((scaleInfo, scaleType) => {
     callback({ ...scaleInfo, scaleType });


### PR DESCRIPTION
Upgrade D3 to 6.3.1. See the [migration guide](https://observablehq.com/@d3/d3v6-migration-guide).

Changes
 * Make all D3 imports in app (not test) code from specific modules rather than `d3`. 
 * D3.event was removed and now the event object is passed to handlers. Changed `ZoomContainer` to reflect this.
 * Fix Histogram test
 * Confirm all `d3-array` dependencies in `package-lock.json` are pointing to `2.9.1` and not `1.x.x`.

We will release this as a major version bump in Reactochart. 4.0!