### PR TITLE
Fix README code block syntax highlight error

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you have an app that depends on reactochart and you want to develop locally, 
 1. In the folder for this repo, run `npm build` and then `npm link`
 2. In your app folder, run `npm link reactochart`. If you're using webpack, then you also may need the following config:
 
-```json
+```js
 {
   "resolve": {
     "symlinks": true,


### PR DESCRIPTION
The last code block on README is using `json` for syntax highlighting while `js` is a better fit given its content (webpack config). This incorrect choice of language leads to an unsightly view for the rendered output:

![image](https://user-images.githubusercontent.com/22449454/169176906-77172bcd-af7b-414e-ab8d-0a021fb0a125.png)
