### PR TITLE
Use sticky sidebar for docs site

### DIFF
--- a/docs/styles/main.less
+++ b/docs/styles/main.less
@@ -14,10 +14,14 @@ body {
 
 .sidebar-nav {
   height: 100%;
-  max-height: 100vh;
-  position: sticky;
-  top: 0;
+  max-height: 300px;
   overflow-y: scroll;
+
+  @media screen and (min-width: 992px) {
+    max-height: 100vh;
+    position: sticky;
+    top: 0;
+  }
   
   h1,
   h2,


### PR DESCRIPTION
Simple sticky sidebar can significantly improve the UX for navigating the docs site. See the following comparisons:

## Large Screen

### Current

https://user-images.githubusercontent.com/22449454/169185059-138e9552-8ae7-4323-a637-acd1f46ed63e.mp4

### With sticky sidebar

https://user-images.githubusercontent.com/22449454/169185085-c67a4f36-fc8d-49f3-8b27-3269a0fb673f.mp4

## Small Screen

### Current

https://user-images.githubusercontent.com/22449454/169185043-fbf1dd9e-5941-4126-ae89-58e4ea96808f.mp4

### With sticky sidebar

https://user-images.githubusercontent.com/22449454/169185023-6c2d98d7-0ab5-4740-a581-444836211084.mp4


